### PR TITLE
[fix] format break_records

### DIFF
--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -3,7 +3,7 @@ import { StringIndexed } from '@slack/bolt/dist/types/helpers';
 import { GasWebClient as SlackClient } from '@hi-se/web-api';
 import { format, setHours, setMinutes, setSeconds, subDays } from 'date-fns';
 
-import { getCompanyEmployees, getWorkRecord, setTimeClocks, updateWorkRecord } from './freee';
+import { getCompanyEmployees, getWorkRecord, setTimeClocks, updateWorkRecord, WorkRecordControllerRequestBody } from './freee';
 import { getUnixTimeStampString, isWorkDay } from './utilities';
 import { getConfig, initConfig } from './config';
 
@@ -314,7 +314,7 @@ const checkAttendance = (client: SlackClient, channelId: string) => {
       const remoteMessage = matchedUnprocessedRemote[0];
       const targetDate = format(clockOutDate, 'yyyy-MM-dd');
       const workRecord = getWorkRecord(employeeId, targetDate, FREEE_COMPANY_ID);
-      const remoteParams = {
+      const remoteParams: WorkRecordControllerRequestBody = {
         company_id: FREEE_COMPANY_ID,
         clock_in_at: format(new Date(workRecord.clock_in_at), 'yyyy-MM-dd HH:mm:ss'),
         clock_out_at: format(new Date(workRecord.clock_out_at), 'yyyy-MM-dd HH:mm:ss'),

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -319,7 +319,12 @@ const checkAttendance = (client: SlackClient, channelId: string) => {
         clock_in_at: format(new Date(workRecord.clock_in_at), 'yyyy-MM-dd HH:mm:ss'),
         clock_out_at: format(new Date(workRecord.clock_out_at), 'yyyy-MM-dd HH:mm:ss'),
         note: workRecord.note ? `${workRecord.note} リモート` : 'リモート',
-        break_records: workRecord.break_records
+        break_records: workRecord.break_records.map(record => {
+          return {
+            clock_in_at: format(new Date(record.clock_in_at), 'yyyy-MM-dd HH:mm:ss'),
+            clock_out_at: format(new Date(record.clock_out_at), 'yyyy-MM-dd HH:mm:ss')
+          }
+        })
       }
 
       try {

--- a/hisyonosuke/src/attendance-manager/freee.ts
+++ b/hisyonosuke/src/attendance-manager/freee.ts
@@ -4,7 +4,7 @@ import { getService } from './auth'
 import { buildUrl } from './utilities'
 
 
-interface CompaniesEmployeeSerializer {
+export interface CompaniesEmployeeSerializer {
   id: number,
   num: string,
   display_name: string,
@@ -13,7 +13,7 @@ interface CompaniesEmployeeSerializer {
   user_id: number,
   email: string
 }
-interface EmployeeSerializer {
+export interface EmployeeSerializer {
   id: number,
   num: string,
   display_name: string,
@@ -24,29 +24,29 @@ interface EmployeeSerializer {
 }
 
 
-interface WorkRecordTimeRangeResponseSerializer {
+export interface WorkRecordTimeRangeResponseSerializer {
   clock_in_at: string, // DATETIME
   clock_out_at: string, // DATETIME
 }
 
-interface EmployeeMultiHourlyWageWorkRecordSummarySerializer {
+export interface EmployeeMultiHourlyWageWorkRecordSummarySerializer {
   name: string,
   total_normal_time_mins: number
 }
 
-interface HolidaysAndHoursSerializer {
+export interface HolidaysAndHoursSerializer {
   days: number,
   hours: number
 }
 
-interface TimeClocksControllerCreateBody {
+export interface TimeClocksControllerCreateBody {
   company_id: number,
   type: 'clock_in' | 'break_begin' | 'break_end' | 'clock_out',
   base_date: string,  // YYYY-MM-DD
   datetime: string,  // YYYY-MM-DD HH:MM:SS
 }
 
-interface WorkRecordControllerRequestBody {
+export interface WorkRecordControllerRequestBody {
   company_id: number,
   break_records?: WorkRecordTimeRangeResponseSerializer[],
   clock_in_at?: string, //DATETIME
@@ -65,7 +65,7 @@ interface WorkRecordControllerRequestBody {
   use_default_work_pattern?: boolean,
 }
 
-interface WorkRecordSummarySerializer {
+export interface WorkRecordSummarySerializer {
   year: number,
   month: number,
   start_date: string, // DateString,
@@ -92,7 +92,7 @@ interface WorkRecordSummarySerializer {
   work_records: WorkRecordSerializer[]
 }
 
-interface WorkRecordSerializer {
+export interface WorkRecordSerializer {
   break_records: WorkRecordTimeRangeResponseSerializer[],
   clock_in_at: number,
   clock_out_at: number,

--- a/hisyonosuke/src/attendance-manager/freee.ts
+++ b/hisyonosuke/src/attendance-manager/freee.ts
@@ -93,7 +93,7 @@ interface WorkRecordSummarySerializer {
 }
 
 interface WorkRecordSerializer {
-  break_records: any,
+  break_records: WorkRecordTimeRangeResponseSerializer[],
   clock_in_at: number,
   clock_out_at: number,
   date: string, // DateString,

--- a/hisyonosuke/src/attendance-manager/freee.ts
+++ b/hisyonosuke/src/attendance-manager/freee.ts
@@ -46,6 +46,8 @@ export interface TimeClocksControllerCreateBody {
   datetime: string,  // YYYY-MM-DD HH:MM:SS
 }
 
+// https://developer.freee.co.jp/docs/hr/reference#/%E5%8B%A4%E6%80%A0/update_employee_work_record
+// 登録済みの勤怠時間の変更・勤務パターンの変更など、要求によってrequiredが変わるため、nullable typeは厳密ではない
 export interface WorkRecordControllerRequestBody {
   company_id: number,
   break_records?: WorkRecordTimeRangeResponseSerializer[],


### PR DESCRIPTION
https://github.com/siiibo/hisyonosuke/pull/6 の追加修正。

以下 https://github.com/siiibo/hisyonosuke/pull/6#issuecomment-1050674701 より転記。

https://developer.freee.co.jp/docs/hr/reference#/%E5%8B%A4%E6%80%A0/get_employee_work_record

```
 "break_records": [
    {
      "clock_in_at": "2022-02-25T09:12:40.156Z",
      "clock_out_at": "2022-02-25T09:12:40.156Z"
    }
  ],
```

勤怠情報をgetしたときのbreak_recordsは↑の形式で来るので `yyyy-MM-dd HH:mm:ss` の形式にformatする必要があった。

（[退勤打刻時](https://siiibo.slack.com/archives/C018XK4E9CG/p1645780102630649?thread_ts=1645746618.487839&cid=C018XK4E9CG
)に発覚。APIを直接叩いてテストしたときはformatされた値を利用していた）

