### PR TITLE
[fix] 「freeeで出勤打刻→Slackで退勤打刻」を行うとリモートメモが追加されるバグの修正

### DIFF
--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -410,7 +410,7 @@ const getActionType = (commandType: CommandType, userWorkStatus: UserWorkStatus 
       return 'switch_work_status_to_remote';
     case 'CLOCK_OUT':
       //TODO: 打刻の重複の場合
-      return !userWorkStatus?.needTrafficExpense ? 'clock_out_and_add_remote_memo' : 'clock_out';
+      return userWorkStatus?.needTrafficExpense === false ? 'clock_out_and_add_remote_memo' : 'clock_out';
   }
 }
 


### PR DESCRIPTION
「Slackで出勤打刻忘れ → freeeで出勤打刻  → Slackで退勤打刻」

↑のように打刻を行うと、リモートメモが追加されてしまうバグの修正