### PR TITLE
[feature] 前日の退勤忘れを出勤打刻時エラーに追加

### DIFF
--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -150,8 +150,13 @@ const execAction = (client: SlackClient, channelId: string, FREEE_COMPANY_ID: nu
     console.error(`user:${employeeId}, type:${actionType}, messageTs: ${message.ts}\n${JSON.stringify(userWorkStatus, null, 2)}`);
 
     let errorFeedBackMessage = e.toString();
-    if (actionType === 'clock_in' && e.message.includes("打刻の種類が正しくありません。")) {
-      errorFeedBackMessage = '既に打刻済みです';
+    if (actionType === 'clock_in') {
+      if (e.message.includes('打刻の日付が不正な値です。')) {
+        errorFeedBackMessage = `前日の退勤を完了してから出勤打刻してください.`;
+      }
+      if (e.message.includes("打刻の種類が正しくありません。")) {
+        errorFeedBackMessage = '既に打刻済みです';
+      }
     }
     if (actionType === 'clock_out' && e.message.includes("打刻の種類が正しくありません。")) {
       errorFeedBackMessage = '出勤打刻が完了していないか、退勤の上書きができない値です.';


### PR DESCRIPTION
前日の退勤を忘れて出勤打刻を行うと「打刻の日付が不正な値です」というエラーが返される([例](https://siiibo.slack.com/archives/CL0V50APP/p1652394316230099?thread_ts=1652394146.912299&cid=CL0V50APP))ようなので、わかりやすいようにフィードバックメッセージを追加。

