### PR TITLE
Fix: 5分以内に複数コマンドがあった場合に正しく処理できるようにする

### DIFF
--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -346,51 +346,37 @@ const getUserWorkStatusesByMessages = (messages: Message[], botUserId: string): 
   return Object.fromEntries(clockedInUserWorkStatuses);
 }
 
+
+const isErrorMessage = (message: Message, botUserId: string): boolean => {
+  return message.reactions?.some(reaction => {
+    return (
+      reaction.users.includes(botUserId) &&
+      reaction.name === REACTION.ERROR
+    );
+  });
+}
+
+const isProcessedMessage = (message: Message, botUserId: string): boolean => {
+  return message.reactions?.some(reaction => {
+    return (
+      reaction.users.includes(botUserId) &&
+      [
+        REACTION.DONE_FOR_TIME_RECORD,
+        REACTION.DONE_FOR_REMOTE_MEMO,
+        REACTION.DONE_FOR_LOCATION_SWITCH
+      ].includes(reaction.name)
+    );
+  });
+}
+
 const getProcessedMessages = (messages: Message[], botUserId: string) => {
-  const messagesWithoutError = messages.filter(message => {
-    return !message.reactions?.some(reaction => {
-      return (
-        reaction.users.includes(botUserId) &&
-        reaction.name === REACTION.ERROR
-      );
-    })
-  });
-  const processedMessages = messagesWithoutError.filter(message => {
-    return message.reactions?.some(reaction => {
-      return (
-        reaction.users.includes(botUserId) &&
-        [
-          REACTION.DONE_FOR_TIME_RECORD,
-          REACTION.DONE_FOR_REMOTE_MEMO,
-          REACTION.DONE_FOR_LOCATION_SWITCH
-        ].includes(reaction.name)
-      )
-    })
-  });
-  return processedMessages;
+  const messagesWithoutError = messages.filter(message => !isErrorMessage(message, botUserId));
+  return messagesWithoutError.filter(message => isProcessedMessage(message, botUserId));
 }
 
 const getUnprocessedMessages = (messages: Message[], botUserId: string) => {
-  const messagesWithoutError = messages.filter(message => {
-    return !message.reactions?.some(reaction => {
-      return (
-        reaction.users.includes(botUserId) &&
-        reaction.name === REACTION.ERROR
-      );
-    })
-  });
-  const unprocessedMessages = messagesWithoutError.filter(message => {
-    return !message.reactions?.some(reaction => {
-      return (
-        reaction.users.includes(botUserId) &&
-        [
-          REACTION.DONE_FOR_TIME_RECORD,
-          REACTION.DONE_FOR_REMOTE_MEMO,
-          REACTION.DONE_FOR_LOCATION_SWITCH
-        ].includes(reaction.name)
-      )
-    })
-  });
+  const messagesWithoutError = messages.filter(message => !isErrorMessage(message, botUserId));
+  const unprocessedMessages = messagesWithoutError.filter(message => !isProcessedMessage(message, botUserId));
   return unprocessedMessages;
 }
 

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -305,8 +305,8 @@ const getUpdatedUserWorkStatus = (
   userWorkStatus: UserWorkStatus,
   newCommand: CommandType,
 ): UserWorkStatus => {
-  const workStatus = getUserWorkStatusByLastCommand(newCommand);
   const userCommands = [...userWorkStatus.processedCommands, newCommand];
+  const workStatus = getUserWorkStatusByCommands(userCommands);
   const needTrafficExpense = userWorkStatus.needTrafficExpense ?
     userWorkStatus.needTrafficExpense :
     checkTrafficExpense(userCommands);
@@ -327,7 +327,7 @@ const getUserWorkStatusesByMessages = (messages: Message[], botUserId: string): 
   const clockedInUserWorkStatuses = clockedInUserIds.map(userSlackId => {
     const userMessages = processedMessages.filter(message => message.user === userSlackId);
     const userCommands = userMessages.map(message => getCommandType(message)).filter(_ => _);
-    const workStatus = getUserWorkStatusByLastCommand(userCommands[userCommands.length - 1]);
+    const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
 
     return [
@@ -383,13 +383,14 @@ const checkTrafficExpense = (userCommands: CommandType[]) => {
 }
 
 
-const getUserWorkStatusByLastCommand = (_lastUserCommand: CommandType): UserWorkStatus['workStatus'] => {
+const getUserWorkStatusByCommands = (commands: CommandType[]): UserWorkStatus['workStatus'] => {
 
+  const lastCommand = commands[commands.length - 1];
   // 最後のuserMessageからworkStatusを算出できるはず
   // 休憩を打刻できるように変更する場合は、休憩打刻を除いた最後のメッセージを確認
   // TODO: ↑の検証
 
-  switch (_lastUserCommand) {
+  switch (lastCommand) {
     case 'CLOCK_OUT':
       return '退勤済み';
     case 'CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE':

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -312,7 +312,9 @@ const getUpdatedUserWorkStatus = (
   const workStatus = getUserWorkStatusByLastCommand(commandType);
   const userMessages = [...userWorkStatus.processedMessages, newMessage];
   const userCommands = userMessages.map(message => getCommandType(message)).filter(_ => _);
-  const needTrafficExpense = checkTrafficExpense(userCommands);
+  const needTrafficExpense = userWorkStatus.needTrafficExpense ?
+    userWorkStatus.needTrafficExpense :
+    checkTrafficExpense(userCommands);
 
   return {
     needTrafficExpense,

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -70,24 +70,17 @@ export const periodicallyCheckForAttendanceManager = () => {
  */
 const checkAttendance = (client: SlackClient, channelId: string) => {
   const hisyonosukeUserId = 'U01AY3RHR42'; // ボットはbot_idとuser_idの2つのidを持ち、リアクションにはuser_idが使われる
+  const { FREEE_COMPANY_ID } = getConfig();
 
   const messages = getDailyMessages(client, channelId);
   if (!messages.length) { return }
 
-  const unprocessedMessages = getUnprocessedMessages(messages, hisyonosukeUserId);
-
-  const unprocessedCommands = unprocessedMessages.map(message => {
-    return {
-      message,
-      commandType: getCommandType(message)
-    }
-  }).filter(_ => _.commandType);
-
-  const { FREEE_COMPANY_ID } = getConfig();
-
   let userWorkStatuses = getUserWorkStatusesByMessages(messages, hisyonosukeUserId);
 
-  unprocessedCommands.forEach(({ message, commandType }) => {
+  const unprocessedMessages = getUnprocessedMessages(messages, hisyonosukeUserId);
+  unprocessedMessages.forEach((message) => {
+    const commandType = getCommandType(message);
+    if (!commandType) { return }
     const userWorkStatus = userWorkStatuses[message.user];
     const actionType = getActionType(commandType, userWorkStatus);
     execAction(client, channelId, FREEE_COMPANY_ID, { message, userWorkStatus, actionType });


### PR DESCRIPTION
既存の実装では5分毎の処理について、最初の段階で既に処理されたメッセージ（打刻完了のフィードバック付きコマンド）から各ユーザーの勤務状態を計算し、勤務状態と最新の入力コマンドから後続の処理を決定している。

そのため、5分以内に同一ユーザーから複数コマンドがあった場合に対応できていない。

↑に対応するには勤務状態の更新処理をコマンドの処理毎に入れ込む必要がある