### PR TITLE
[attendance-manager] Fix: リモート → 出社に切り替えた際の通勤費判定を修正

### DIFF
--- a/hisyonosuke/package.json
+++ b/hisyonosuke/package.json
@@ -16,6 +16,7 @@
     "date-fns": "^2.28.0",
     "moment": "^2.29.1",
     "neverthrow": "^6.0.0",
+    "remeda": "^1.11.0",
     "ts-pattern": "^4.2.1",
     "zod": "^3.21.4"
   },

--- a/hisyonosuke/src/attendance-manager/message.ts
+++ b/hisyonosuke/src/attendance-manager/message.ts
@@ -1,5 +1,6 @@
 import { GasWebClient as SlackClient } from "@hi-se/web-api";
 import { z } from "zod";
+import * as R from "remeda";
 import { getDate, subDays, set } from "date-fns";
 import { REACTION, ReactionSchema } from "./reaction";
 import { getUnixTimeStampString } from "./utilities";
@@ -63,13 +64,15 @@ function getDailyMessages(client: SlackClient, channelId: string, dateStartHour:
       inclusive: true,
     }).messages || [];
 
-  // 時系列昇順に並び替え
-  return _messages
-    .map((m) => {
+  return R.pipe(
+    _messages,
+    R.map((m) => {
       const parsed = MessageSchema.safeParse(m);
       return parsed.success ? parsed.data : undefined;
-    })
-    .filter((m): m is Message => !!m);
+    }),
+    R.filter((m): m is Message => !!m),
+    R.sortBy((m) => m.date)
+  );
 }
 
 function isErrorMessage(message: Message, botUserId: string): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5116,6 +5116,11 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remeda@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/remeda/-/remeda-1.11.0.tgz#9c0259ca360fbaba9cfbb40a7fd784407db4a388"
+  integrity sha512-9eYmE5zbmy5d8R260QAk72ZmZoHH7lmLlQrR9ILi9i+vLpBwvve9+fsytvNGzWRfagml7o5DCx8541DC+++y+w==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
https://siiibo.slack.com/archives/C03R8GYG56C/p1680485834775589 より

3/13まではリモート → 出社切替時の通勤費判定が正常に動いているが、3/15以降出社に切り替えても退勤時にリモートメモが追加されてしまっているので修正する


🔗 https://trello.com/c/qARCn6MG