### PR TITLE
[Hisyonosuke] Chore: development環境の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 build/
-.clasp.json
+.clasp*.json

--- a/hisyonosuke/package.json
+++ b/hisyonosuke/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "open": "yarn clasp open",
     "build": "yarn webpack",
-    "buildpush": "yarn webpack && clasp push --force",
+    "buildpush:prod": "yarn webpack && cross-env clasp_config_project=.clasp.prod.json clasp push --force",
+    "buildpush:dev": " yarn webpack && cross-env clasp_config_project=.clasp.dev.json clasp push --force",
     "postinstall": "mkdir -p build && cp appsscript.json build/appsscript.json"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
     "@types/google-apps-script-oauth2": ">=38.0.0",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.36.0",
     "gas-webpack-plugin": "^2.0.0",
     "prettier": "^2.8.4",

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -2,7 +2,7 @@ import { GasWebClient as SlackClient } from "@hi-se/web-api";
 import { format, subDays, toDate } from "date-fns";
 import { getCompanyEmployees, getWorkRecord, setTimeClocks, updateWorkRecord } from "./freee";
 import type { EmployeesWorkRecordsController_update_body } from "./freee.schema";
-import { getConfig, initConfig } from "./config";
+import { getConfig } from "./config";
 import { REACTION } from "./reaction";
 import { Message, getCategorizedDailyMessages } from "./message";
 import { getCommandType } from "./command";
@@ -14,8 +14,6 @@ import { match, P } from "ts-pattern";
 const DATE_START_HOUR = 4;
 
 export function initAttendanceManager() {
-  initConfig();
-
   const targetFunction = periodicallyCheckForAttendanceManager;
 
   ScriptApp.getProjectTriggers().forEach((trigger) => {

--- a/hisyonosuke/src/attendance-manager/attendanceManager.ts
+++ b/hisyonosuke/src/attendance-manager/attendanceManager.ts
@@ -28,11 +28,12 @@ export function initAttendanceManager() {
 export function periodicallyCheckForAttendanceManager() {
   const client = getSlackClient();
 
-  const { ATTENDANCE_CHANNEL_ID, PART_TIMER_CHANNEL_ID } = getConfig();
+  const { CHANNEL_IDS, BOT_USER_ID } = getConfig();
 
   // チャンネルごとに関数自体を分けて別プロセス（別のタイムトリガー）で動かすように変更する可能性あり
-  checkAttendance(client, ATTENDANCE_CHANNEL_ID);
-  checkAttendance(client, PART_TIMER_CHANNEL_ID);
+  CHANNEL_IDS.forEach((channelId) => {
+    checkAttendance(client, channelId, BOT_USER_ID);
+  });
 }
 
 /*
@@ -41,14 +42,13 @@ export function periodicallyCheckForAttendanceManager() {
   triggerの呼び出し毎に、処理済みのメッセージも含めてチェックするという冗長な処理になってしまっている。
   いずれPropServiceなどを使って状態管理するほうが良いかもしれない。
  */
-function checkAttendance(client: SlackClient, channelId: string) {
-  const hisyonosukeUserId = "U01AY3RHR42"; // ボットはbot_idとuser_idの2つのidを持ち、リアクションにはuser_idが使われる
+function checkAttendance(client: SlackClient, channelId: string, botUserId: string) {
   const { FREEE_COMPANY_ID } = getConfig();
 
   const { processedMessages, unprocessedMessages } = getCategorizedDailyMessages(
     client,
     channelId,
-    hisyonosukeUserId,
+    botUserId,
     DATE_START_HOUR
   );
   if (!unprocessedMessages.length && !processedMessages.length) return;

--- a/hisyonosuke/src/attendance-manager/auth.ts
+++ b/hisyonosuke/src/attendance-manager/auth.ts
@@ -13,7 +13,7 @@ export function getService() {
     .setClientId(CLIENT_ID)
     .setClientSecret(CLIENT_SECRET)
     .setCallbackFunction(authCallback.name)
-    .setPropertyStore(PropertiesService.getUserProperties()); // とりあえず@hi-seのUserPropに保持している
+    .setPropertyStore(PropertiesService.getScriptProperties());
 }
 
 export function authCallback(request: any) {
@@ -30,7 +30,7 @@ export function authCallback(request: any) {
 export function printAuth() {
   const props = PropertiesService.getScriptProperties().getProperties();
   console.log(props);
-  console.log(PropertiesService.getUserProperties().getProperties());
+  console.log(PropertiesService.getScriptProperties().getProperties());
 }
 
 export function resetAuth() {

--- a/hisyonosuke/src/attendance-manager/config.ts
+++ b/hisyonosuke/src/attendance-manager/config.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-const CONFIG_SPREADSHEET_ID = "1fAxgi14OJx6f8RrnUMMoELF--mSZPMWgl3Zz_CUGYL8";
-
 const ConfigSchema = z.object({
   ATTENDANCE_MANAGER_ENV: z.union([z.literal("production"), z.literal("development")]),
   FREEE_CLIENT_ID: z.string(),
@@ -20,22 +18,4 @@ export type Config = z.infer<typeof ConfigSchema>;
 export function getConfig(): Config {
   const props = PropertiesService.getScriptProperties().getProperties();
   return ConfigSchema.parse(props);
-}
-
-export function initConfig(): void {
-  const sheet = SpreadsheetApp.openById(CONFIG_SPREADSHEET_ID).getSheets()[0];
-  const values = sheet
-    .getRange(2, 2, sheet.getLastRow() - 1, 1)
-    .getValues()
-    .flat();
-  const configs = {
-    FREEE_CLIENT_ID: values[0],
-    FREEE_CLIENT_SECRET: values[1],
-    FREEE_COMPANY_ID: values[2],
-    SLACK_TOKEN: values[3],
-    ATTENDANCE_CHANNEL_ID: values[4],
-    PART_TIMER_CHANNEL_ID: values[5],
-    TEST_CHANNEL_ID: values[6],
-  };
-  PropertiesService.getScriptProperties().setProperties(configs);
 }

--- a/hisyonosuke/src/attendance-manager/config.ts
+++ b/hisyonosuke/src/attendance-manager/config.ts
@@ -1,26 +1,22 @@
+import { z } from "zod";
+
 const CONFIG_SPREADSHEET_ID = "1fAxgi14OJx6f8RrnUMMoELF--mSZPMWgl3Zz_CUGYL8";
 
-interface Config {
-  FREEE_CLIENT_ID: string;
-  FREEE_CLIENT_SECRET: string;
-  FREEE_COMPANY_ID: number;
-  SLACK_TOKEN: string;
-  ATTENDANCE_CHANNEL_ID: string;
-  PART_TIMER_CHANNEL_ID: string;
-  TEST_CHANNEL_ID: string;
-}
+const ConfigSchema = z.object({
+  FREEE_CLIENT_ID: z.string(),
+  FREEE_CLIENT_SECRET: z.string(),
+  FREEE_COMPANY_ID: z.preprocess((v) => Number(v), z.number()),
+  SLACK_TOKEN: z.string(),
+  ATTENDANCE_CHANNEL_ID: z.string(),
+  PART_TIMER_CHANNEL_ID: z.string(),
+  TEST_CHANNEL_ID: z.string(),
+});
+
+export type Config = z.infer<typeof ConfigSchema>;
 
 export function getConfig(): Config {
   const props = PropertiesService.getScriptProperties().getProperties();
-  return {
-    FREEE_CLIENT_ID: props["FREEE_CLIENT_ID"],
-    FREEE_CLIENT_SECRET: props["FREEE_CLIENT_SECRET"],
-    FREEE_COMPANY_ID: Number(props["FREEE_COMPANY_ID"]),
-    SLACK_TOKEN: props["SLACK_TOKEN"],
-    ATTENDANCE_CHANNEL_ID: props["ATTENDANCE_CHANNEL_ID"],
-    PART_TIMER_CHANNEL_ID: props["PART_TIMER_CHANNEL_ID"],
-    TEST_CHANNEL_ID: props["TEST_CHANNEL_ID"],
-  };
+  return ConfigSchema.parse(props);
 }
 
 export function initConfig(): void {

--- a/hisyonosuke/src/attendance-manager/config.ts
+++ b/hisyonosuke/src/attendance-manager/config.ts
@@ -8,6 +8,8 @@ const ConfigSchema = z.object({
   FREEE_CLIENT_SECRET: z.string(),
   FREEE_COMPANY_ID: z.preprocess((v) => Number(v), z.number()),
   SLACK_TOKEN: z.string(),
+  BOT_USER_ID: z.string(), // ボットはbot_idとuser_idの2つのidを持ち、リアクションにはuser_idが使われる
+  CHANNEL_IDS: z.string().transform((v) => v.replace(/\s/g, "").split(",")),
   ATTENDANCE_CHANNEL_ID: z.string(),
   PART_TIMER_CHANNEL_ID: z.string(),
   TEST_CHANNEL_ID: z.string(),

--- a/hisyonosuke/src/attendance-manager/config.ts
+++ b/hisyonosuke/src/attendance-manager/config.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const CONFIG_SPREADSHEET_ID = "1fAxgi14OJx6f8RrnUMMoELF--mSZPMWgl3Zz_CUGYL8";
 
 const ConfigSchema = z.object({
+  ATTENDANCE_MANAGER_ENV: z.union([z.literal("production"), z.literal("development")]),
   FREEE_CLIENT_ID: z.string(),
   FREEE_CLIENT_SECRET: z.string(),
   FREEE_COMPANY_ID: z.preprocess((v) => Number(v), z.number()),

--- a/hisyonosuke/src/attendance-manager/config.ts
+++ b/hisyonosuke/src/attendance-manager/config.ts
@@ -8,9 +8,6 @@ const ConfigSchema = z.object({
   SLACK_TOKEN: z.string(),
   BOT_USER_ID: z.string(), // ボットはbot_idとuser_idの2つのidを持ち、リアクションにはuser_idが使われる
   CHANNEL_IDS: z.string().transform((v) => v.replace(/\s/g, "").split(",")),
-  ATTENDANCE_CHANNEL_ID: z.string(),
-  PART_TIMER_CHANNEL_ID: z.string(),
-  TEST_CHANNEL_ID: z.string(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1815,7 +1822,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
秘書之介に変更を入れる際、Productionコードに開発中のコードを適用してまうとバグが発生した場合に打刻ができなくなってしまって不便なので、開発用のSlack Appを導入する

休憩打刻追加ようのブランチで作業していたが、差分が大きくなりそうだったので先にこちらを導入

- production, developmentでGASプロジェクトそのものを分ける
- それぞれでproduction用, development用のWeb App URLを発行する
- development用のSlack Appも追加し、それぞれに対応するURLを割り当てる



:link: https://trello.com/c/DUHEpL2J