### PR TITLE
Feature(attendance-manager): fetch関数の挙動をenvで切り分け

### DIFF
--- a/hisyonosuke/package.json
+++ b/hisyonosuke/package.json
@@ -5,7 +5,8 @@
   "main": "build",
   "private": true,
   "scripts": {
-    "open": "yarn clasp open",
+    "open:prod": "cross-env clasp_config_project=.clasp.prod.json yarn clasp open",
+    "open:dev": "cross-env clasp_config_project=.clasp.dev.json yarn clasp open",
     "build": "yarn webpack",
     "buildpush:prod": "yarn webpack && cross-env clasp_config_project=.clasp.prod.json clasp push --force",
     "buildpush:dev": " yarn webpack && cross-env clasp_config_project=.clasp.dev.json clasp push --force",

--- a/hisyonosuke/src/attendance-manager/freee.ts
+++ b/hisyonosuke/src/attendance-manager/freee.ts
@@ -8,8 +8,10 @@ import type {
 } from "./freee.schema";
 import { getService } from "./auth";
 import { buildUrl } from "./utilities";
+import { getConfig } from "./config";
 
-const fetch = createFetch(getService().getAccessToken());
+const fetch =
+  getConfig().ATTENDANCE_MANAGER_ENV === "production" ? createFetch(getService().getAccessToken()) : UrlFetchApp.fetch;
 
 function createFetch(accessToken: string) {
   return <Schema>(


### PR DESCRIPTION
Dev環境でcreateFetchが呼び出されるとfreeeのtokenがexpiredでエラーとなるので、環境変数で切り分ける

https://github.com/siiibo/hisyonosuke/pull/30 関連

:link: https://trello.com/c/fWr8KHHN

