### PR TITLE
社員メンションの追加

### DIFF
--- a/hisyonosuke/src/shift-changer/config.ts
+++ b/hisyonosuke/src/shift-changer/config.ts
@@ -6,7 +6,7 @@ const ConfigSchema = z.object({
   SLACK_ACCESS_TOKEN: z.string(),
   SLACK_CHANNEL_TO_POST: z.string(),
   JOB_SHEET_URL: z.string(),
-  MEMBER_ID: z.string(),
+  HR_MANAGER_SLACK_ID: z.string(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -559,7 +559,7 @@ const getManagerIds = (managerEmails: string[], client: SlackClient): string[] =
 
 const getMentionMessage = (managerIds: string[]): string => {
   const mentionMessages = managerIds.map((managerId) => {
-    `<@${managerId}>\n`;
+    return `<@${managerId}>\n`;
   });
   const mentionMessage = mentionMessages.join("");
   return mentionMessage;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -534,7 +534,7 @@ const getManagerEmails = (userEmail: string): string[] => {
   return managerEmails;
 };
 
-const getManagerIds = (managerEmails: string[], client: SlackClient): string[] => {
+const getManagerSlackIds = (managerEmails: string[], client: SlackClient): string[] => {
   const slackMembers = client.users.list().members ?? [];
 
   const siiiboSlackMembers = slackMembers.filter(
@@ -544,7 +544,7 @@ const getManagerIds = (managerEmails: string[], client: SlackClient): string[] =
       slackMember.id !== "USLACKBOT" &&
       slackMember.profile?.email?.includes("siiibo.com")
   );
-  const managerIds = managerEmails
+  const managerSlackIds = managerEmails
     .map((email) => {
       const member = siiiboSlackMembers.find((slackMember) => {
         return slackMember.profile?.email === email;
@@ -554,12 +554,12 @@ const getManagerIds = (managerEmails: string[], client: SlackClient): string[] =
     })
     .filter((id): id is string => id !== undefined);
 
-  return managerIds;
+  return managerSlackIds;
 };
 
-const getMentionMessage = (managerIds: string[]): string => {
-  const mentionMessages = managerIds.map((managerId) => {
-    return `<@${managerId}>\n`;
+const getMentionMessage = (managerSlackIds: string[]): string => {
+  const mentionMessages = managerSlackIds.map((managerSlackId) => {
+    return `<@${managerSlackId}>\n`;
   });
   const mentionMessage = mentionMessages.join("");
   return mentionMessage;
@@ -573,8 +573,8 @@ const postMessageToSlackChannel = (
 ) => {
   const { HR_MANAGER_SLACK_ID } = getConfig();
   const managerEmails = getManagerEmails(userEmail);
-  const managerIds = getManagerIds(managerEmails, client);
-  const mentionMessageToManagers = getMentionMessage(managerIds);
+  const managerSlackIds = getManagerSlackIds(managerEmails, client);
+  const mentionMessageToManagers = getMentionMessage(managerSlackIds);
   client.chat.postMessage({
     channel: slackChannelToPost,
     text: `<@${HR_MANAGER_SLACK_ID}>\n${mentionMessageToManagers}${messageToNotify}`,

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -537,16 +537,9 @@ const getManagerEmails = (userEmail: string): string[] => {
 const getManagerSlackIds = (managerEmails: string[], client: SlackClient): string[] => {
   const slackMembers = client.users.list().members ?? [];
 
-  const siiiboSlackMembers = slackMembers.filter(
-    (slackMember) =>
-      !slackMember.deleted &&
-      !slackMember.is_bot &&
-      slackMember.id !== "USLACKBOT" &&
-      slackMember.profile?.email?.includes("siiibo.com")
-  );
   const managerSlackIds = managerEmails
     .map((email) => {
-      const member = siiiboSlackMembers.find((slackMember) => {
+      const member = slackMembers.find((slackMember) => {
         return slackMember.profile?.email === email;
       });
       if (member === undefined) throw new Error("The email is not in the slack members");

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -571,12 +571,12 @@ const postMessageToSlackChannel = (
   messageToNotify: string,
   userEmail: string
 ) => {
-  const { MEMBER_ID } = getConfig();
+  const { HR_MANAGER_SLACK_ID } = getConfig();
   const managerEmails = getManagerEmails(userEmail);
   const managerIds = getManagerIds(managerEmails, client);
   const mentionMessageToManagers = getMentionMessage(managerIds);
   client.chat.postMessage({
     channel: slackChannelToPost,
-    text: `<@${MEMBER_ID}>\n${mentionMessageToManagers}${messageToNotify}`,
+    text: `<@${HR_MANAGER_SLACK_ID}>\n${mentionMessageToManagers}${messageToNotify}`,
   });
 };

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -530,7 +530,7 @@ const getManagerEmails = (userEmail: string): string[] => {
   });
   if (partTimerInfo === undefined) throw new Error("no part timer information for the email");
   const managerEmail = partTimerInfo[3] as string;
-  const managerEmails = managerEmail.split(/[\s,]+/);
+  const managerEmails = managerEmail.replace(/\s*,\s*/, ",").split(",");
   return managerEmails;
 };
 

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -557,13 +557,7 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
   return managerSlackIds;
 };
 
-const getMentionMessage = (managerSlackIds: string[]): string => {
-  const mentionMessages = managerSlackIds.map((managerSlackId) => {
-    return `<@${managerSlackId}>\n`;
-  });
-  const mentionMessage = mentionMessages.join("");
-  return mentionMessage;
-};
+const slackIdToMention = (slackId: string) => `<@${slackId}>`;
 
 const postMessageToSlackChannel = (
   client: SlackClient,
@@ -574,9 +568,9 @@ const postMessageToSlackChannel = (
   const { HR_MANAGER_SLACK_ID } = getConfig();
   const managerEmails = getManagerEmails(userEmail);
   const managerSlackIds = getManagerSlackIds(managerEmails, client);
-  const mentionMessageToManagers = getMentionMessage(managerSlackIds);
+  const mentionMessageToManagers = [HR_MANAGER_SLACK_ID, ...managerSlackIds].map(slackIdToMention).join(" ");
   client.chat.postMessage({
     channel: slackChannelToPost,
-    text: `<@${HR_MANAGER_SLACK_ID}>\n${mentionMessageToManagers}${messageToNotify}`,
+    text: `${mentionMessageToManagers}\n${messageToNotify}`,
   });
 };

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -530,7 +530,7 @@ const getManagerEmails = (userEmail: string): string[] => {
   });
   if (partTimerInfo === undefined) throw new Error("no part timer information for the email");
   const managerEmail = partTimerInfo[3] as string;
-  const managerEmails = managerEmail.replace(/\s*,\s*/, ",").split(",");
+  const managerEmails = managerEmail.replaceAll(/\s/, "").split(",");
   return managerEmails;
 };
 


### PR DESCRIPTION
シフトの操作があった際、業務に関わってる社員にもメンションが飛ぶようにした
アルバイトDB (https://docs.google.com/spreadsheets/d/1wad1H4i8h0VeijW75Wyu7VKrklvUyoYSmO6hOS3w-TE/edit#gid=0) のD列から取ってくる。複数社員含む場合は カンマ区切り、半角空白。

[trello](https://trello.com/c/zAKcEMgk)