### PR TITLE
社員メンション追加時のバグ修正

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -530,7 +530,7 @@ const getManagerEmails = (userEmail: string): string[] => {
   });
   if (partTimerInfo === undefined) throw new Error("no part timer information for the email");
   const managerEmail = partTimerInfo[3] as string;
-  const managerEmails = managerEmail.replaceAll(/\s/, "").split(",");
+  const managerEmails = managerEmail.replaceAll(/\s/g, "").split(",");
   return managerEmails;
 };
 


### PR DESCRIPTION
replaceAllに正規表現を利用した際、実行時に以下のエラーが出てしまった。
```
TypeError: String.prototype.replaceAll called with a non-global RegExp argument
```
グローバルな正規表現を利用してなかったことが原因だったので、修正した。