### PR TITLE
fix(ci): paths-ignoreをpathsに統合

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,7 @@ on:
             - "main"
         paths:
             - hisyonosuke
-        paths-ignore:
-            - "**.md"
+            - "!**.md"
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GHAのpathsとpaths-ignoreは一緒に使えないらしいので、pathsに統合する

🔗 https://trello.com/c/bd0ZGNuj