### PR TITLE
ci(hisyonosuke): pathsに.githubの追加 & 末尾に/**の追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ on:
         branches:
             - "main"
         paths:
-            - hisyonosuke
+            - hisyonosuke/**
+            - .github/**
             - "!**.md"
     workflow_dispatch:
 


### PR DESCRIPTION
https://github.com/siiibo/hisyonosuke/pull/46 でpaths-ignoreをpathsに統合したが、hisyonosukeディレクトリの指定のみだとGHAを更新した際にGHAがトリガーされないので .github/を追加する

🔗 https://trello.com/c/bd0ZGNuj