### PR TITLE
ci(hisyonosuke): use sha for GAS deployment description

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,4 +37,4 @@ jobs:
                   command: "deploy"
                   deployId: ${{ secrets.DEPLOY_ID }}
                   rootDir: "hisyonosuke/build"
-                  description: ${{ github.event.head_commit.message }}
+                  description: ${{ github.sha }}


### PR DESCRIPTION
clasp deployに渡すdescriptionをgithub.shaに変更する。

https://github.com/siiibo/hisyonosuke/pull/45#discussion_r1275887852 にある通り、clasp deployするために利用しているGHAの https://github.com/daikikatsuragawa/clasp-action ではdescriptionの変数がquoteされておらず、commit messageが空白や特殊文字を境目に途切れてしまう問題があるため。

🔗 https://trello.com/c/bd0ZGNuj