### PR TITLE
勤務場所が空にならないようにする

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -254,6 +254,7 @@ const getModificationInfos = (
         const newRestStartTime = row.newRestStartTime as string;
         const newRestEndTime = row.newRestEndTime as string;
         const newWorkingStyle = row.newWorkingStyle;
+        if (newWorkingStyle === "") throw new Error("new working style is not defined");
         const newTitle = createTitleFromEventInfo(
           { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
           userEmail,
@@ -405,6 +406,7 @@ const getRegistrationInfos = (
       const startTime = format(eventInfo[1] as Date, "HH:mm");
       const endTime = format(eventInfo[2] as Date, "HH:mm");
       const workingStyle = eventInfo[5] as string;
+      if (workingStyle === "") throw new Error("working style is not defined");
       if (eventInfo[3] === "" || eventInfo[4] === "") {
         const restStartTime = eventInfo[3] as string;
         const restEndTime = eventInfo[4] as string;


### PR DESCRIPTION
勤務場所が空でも、そのまま予定が登録されてしまう。そのため、勤務場所が空の場合はエラーを飛ばすようにした。
[参考Trello](https://trello.com/c/jjyI9fg3)