### PR TITLE
シフト変更通知用の名前をアルバイトDBから取得する

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -5,12 +5,6 @@ import { EventInfo } from "./shift-changer-api";
 
 type SheetType = "registration" | "modificationAndDeletion";
 type OperationType = "registration" | "modificationAndDeletion" | "showEvents";
-type PartTimerInfo = {
-  job: string;
-  name: string;
-  email: string;
-  managerEmails: string[];
-};
 
 export const onOpen = () => {
   const ui = SpreadsheetApp.getUi();
@@ -441,7 +435,14 @@ const getSlackClient = (slackToken: string): SlackClient => {
   return new SlackClient(slackToken);
 };
 
-const getPartTimerProfile = (userEmail: string): PartTimerInfo => {
+const getPartTimerProfile = (
+  userEmail: string
+): {
+  job: string;
+  name: string;
+  email: string;
+  managerEmails: string[];
+} => {
   const { JOB_SHEET_URL } = getConfig();
   const sheet = SpreadsheetApp.openByUrl(JOB_SHEET_URL).getSheetByName("シート1");
   if (!sheet) throw new Error("SHEET is not defined");
@@ -460,7 +461,7 @@ const getPartTimerProfile = (userEmail: string): PartTimerInfo => {
   });
   if (partTimerProfile === undefined) throw new Error("no part timer information for the email");
 
-  return partTimerProfile as PartTimerInfo;
+  return partTimerProfile;
 };
 
 const createMessageFromEventInfo = (eventInfo: EventInfo) => {

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -416,7 +416,7 @@ const createTitleFromEventInfo = (
   },
   userEmail: string
 ): string => {
-  const [job, name] = getJobSheetProfile(userEmail);
+  const [job, name] = getPartTimerProfile(userEmail);
 
   const restStartTime = eventInfo.restStartTime;
   const restEndTime = eventInfo.restEndTime;
@@ -435,7 +435,7 @@ const getSlackClient = (slackToken: string): SlackClient => {
   return new SlackClient(slackToken);
 };
 
-const getJobSheetProfile = (userEmail: string): [string, string] => {
+const getPartTimerProfile = (userEmail: string): [string, string] => {
   const { JOB_SHEET_URL } = getConfig();
   const sheet = SpreadsheetApp.openByUrl(JOB_SHEET_URL).getSheetByName("シート1");
   if (!sheet) throw new Error("SHEET is not defined");


### PR DESCRIPTION
シフト変更用の名前をslackのプロフィールから取得していたが、アルバイトDBからemailと付き合わせることで取得する方式に変更した。
[参考Trello](https://trello.com/c/TG2jdXH5)