### PR TITLE
The email is not in the slack members エラーの解消

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -514,7 +514,7 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
       const member = slackMembers.find((slackMember) => {
         return slackMember.profile?.email === email;
       });
-      if (member === undefined) throw new Error("The email is not in the slack members");
+      if (member === undefined) throw new Error("The manager email is not in the slack members");
       return member.id;
     })
     .filter((id): id is string => id !== undefined);

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -455,7 +455,7 @@ const getPartTimerProfile = (
       job: row[0] as string,
       name: row[1] as string,
       email: row[2] as string,
-      managerEmails: (row[3] as string).replaceAll(/\s/g, "").split(","),
+      managerEmails: row[3] === "" ? [] : (row[3] as string).replaceAll(/\s/g, "").split(","),
     }));
 
   const partTimerProfile = partTimerProfiles.find(({ email }) => {

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -455,7 +455,7 @@ const getPartTimerProfile = (
       job: row[0] as string,
       name: row[1] as string,
       email: row[2] as string,
-      managerEmails: row[3] === "" ? [] : (row[3] as string).replaceAll(/\s/g, "").split(","),
+      managerEmails: (row[3] as string).replaceAll(/\s/g, "").split(","),
     }));
 
   const partTimerProfile = partTimerProfiles.find(({ email }) => {


### PR DESCRIPTION
シフト提出時に “The email is not in the slack members” エラーが出てしまう。
managerEmail欄が空文字だと、slackMemberからメンバーを見つけられない → エラーを吐く という流れ。
managerEmailが空文字の場合は、managerEmailsを空配列にすることで、slackId取得時のエラーを吐かないようにした。
[参考Trello](https://trello.com/c/cwMWAf77)