### PR TITLE
「範囲の行数には 1 以上を指定してください。」エラーの解消

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -348,10 +348,6 @@ export const callShowEvents = () => {
   const operationType: OperationType = "showEvents";
   const startDate: Date = sheet.getRange("A5").getValue();
 
-  if (sheet.getLastRow() > 8) {
-    sheet.getRange(9, 1, sheet.getLastRow() - 8, sheet.getLastColumn()).clearContent();
-  }
-
   const payload = {
     apiId: "shift-changer",
     operationType: operationType,
@@ -372,6 +368,10 @@ export const callShowEvents = () => {
   const moldedEventInfos = eventInfos.map(({ title, date, startTime, endTime }) => {
     return [title, date, startTime, endTime];
   });
+
+  if (sheet.getLastRow() > 8) {
+    sheet.getRange(9, 1, sheet.getLastRow() - 8, sheet.getLastColumn()).clearContent();
+  }
 
   sheet.getRange(9, 1, moldedEventInfos.length, moldedEventInfos[0].length).setValues(moldedEventInfos);
 };

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -348,7 +348,9 @@ export const callShowEvents = () => {
   const operationType: OperationType = "showEvents";
   const startDate: Date = sheet.getRange("A5").getValue();
 
-  sheet.getRange(9, 1, sheet.getLastRow() - 8, sheet.getLastColumn()).clearContent();
+  if (sheet.getLastRow() > 8) {
+    sheet.getRange(9, 1, sheet.getLastRow() - 8, sheet.getLastColumn()).clearContent();
+  }
 
   const payload = {
     apiId: "shift-changer",


### PR DESCRIPTION
シフト変更ツールのシフト変更 / 削除で「予定の表示」をクリックすると、「範囲の行数には 1 以上を指定してください。」エラーが出てしまう。
<img width="472" alt="スクリーンショット 2023-08-01 13 47 06" src="https://github.com/siiibo/hisyonosuke/assets/79243520/a2810ea5-e3b7-42e2-9040-3f48ef3dd782">

これは、予定を表示する際にシートの値をクリアするが (すでに予定を表示している場合、そのまま上書きするのを避けるため) 、シートの値が元からないときに`getRange`で取得する行数が0行となるためエラーが出ている。

[参考Trello](https://trello.com/c/DwaYJEZF)