### PR TITLE
通知のフォーマットを変更する

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -564,7 +564,7 @@ const createDeletionMessage = (
   partTimerProfile: PartTimerProfile
 ): string | undefined => {
   const messages = deletionSheetValues.map((sheetValue) => {
-    const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
+    const { workingStyle, restStartTime, restEndTime } = getEventInfoFromTitle(sheetValue.title);
     return createMessageFromEventInfo({
       date: sheetValue.date,
       startTime: sheetValue.startTime,
@@ -600,7 +600,7 @@ const createModificationMessage = (
   partTimerProfile: PartTimerProfile
 ): string | undefined => {
   const modificationSheetInfos = modificationSheetValues.map((sheetValue) => {
-    const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
+    const { workingStyle, restStartTime, restEndTime } = getEventInfoFromTitle(sheetValue.title);
     return {
       previousEventInfo: {
         date: sheetValue.date,
@@ -651,7 +651,7 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
   return managerSlackIds;
 };
 
-const getInfoFromTitle = (
+const getEventInfoFromTitle = (
   title: string
 ): { workingStyle: string; restStartTime: Date | string; restEndTime: Date | string } => {
   const workingStyleRegex = /【(.*?)】/;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -554,10 +554,9 @@ const getEventInfoFromTitle = (title: string): { workingStyle: string; restStart
   const matchResult = title.match(workingStyleRegex);
   const workingStyle = matchResult ? matchResult[1] : "未設定";
 
-  const restTimeRegex = /\(休憩: (.*?)\)/;
-  const restTimeResult = title.match(restTimeRegex);
-  const restStartTime = restTimeResult ? restTimeResult[1].split("~")[0] : "";
-  const restEndTime = restTimeResult ? restTimeResult[1].split("~")[1] : "";
+  const restTimeRegex = /\d{2}:\d{2}~\d{2}:\d{2}/;
+  const restTimeResult = title.match(restTimeRegex)?.[0];
+  const [restStartTime, restEndTime] = restTimeResult ? restTimeResult.split("~") : ["", ""];
   return { workingStyle, restStartTime, restEndTime };
 };
 const slackIdToMention = (slackId: string) => `<@${slackId}>`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -478,7 +478,7 @@ const createMessageFromEventInfo = (eventInfo: EventInfo) => {
   const matchResult = eventInfo.title.match(workingStyleRegex);
   if (!matchResult) throw new Error("no workingStyle matching workingStyleRegex found");
   const workingStyle = matchResult[0];
-  return `${workingStyle}: ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
+  return `${workingStyle} ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
 };
 
 const createRegistrationMessage = (registrationInfos: EventInfo[], comment: string, userEmail: string): string => {
@@ -510,8 +510,8 @@ const createModificationMessage = (
 ): string | undefined => {
   const messages = modificationInfos.map(({ previousEventInfo, newEventInfo }) => {
     return `---
-    ${createMessageFromEventInfo(previousEventInfo)}\n\
-    ↓\n\
+    ${createMessageFromEventInfo(previousEventInfo)}\n
+    ↓\n
     ${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -551,8 +551,8 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
 
 const getEventInfoFromTitle = (title: string): { workingStyle: string; restStartTime: string; restEndTime: string } => {
   const workingStyleRegex = /【(.*?)】/;
-  const matchResult = title.match(workingStyleRegex);
-  const workingStyle = matchResult ? matchResult[1] : "未設定";
+  const matchResult = title.match(workingStyleRegex)?.[1];
+  const workingStyle = matchResult ?? "未設定";
 
   const restTimeRegex = /\d{2}:\d{2}~\d{2}:\d{2}/;
   const restTimeResult = title.match(restTimeRegex)?.[0];

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -400,12 +400,7 @@ const getSheet = (sheetType: SheetType, spreadsheetUrl: string): GoogleAppsScrip
 
 const getRegistrationInfos = (
   sheet: GoogleAppsScript.Spreadsheet.Sheet,
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): EventInfo[] => {
   const registrationInfos = sheet
     .getRange(5, 1, sheet.getLastRow() - 4, sheet.getLastColumn())

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -254,11 +254,11 @@ const getModificationInfos = (
       const newDate = format(row.newDate, "yyyy-MM-dd");
       const newStartTime = format(row.newStartTime, "HH:mm");
       const newEndTime = format(row.newEndTime, "HH:mm");
+      const newWorkingStyle = row.newWorkingStyle;
+      if (newWorkingStyle === "") throw new Error("new working style is not defined");
       if (row.newRestStartTime === "" || row.newRestEndTime === "") {
         const newRestStartTime = row.newRestStartTime as string;
         const newRestEndTime = row.newRestEndTime as string;
-        const newWorkingStyle = row.newWorkingStyle;
-        if (newWorkingStyle === "") throw new Error("new working style is not defined");
         const newTitle = createTitleFromEventInfo(
           { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
           partTimerProfile
@@ -270,7 +270,6 @@ const getModificationInfos = (
       } else {
         const newRestStartTime = format(row.newRestStartTime as Date, "HH:mm");
         const newRestEndTime = format(row.newRestEndTime as Date, "HH:mm");
-        const newWorkingStyle = row.newWorkingStyle;
         const newTitle = createTitleFromEventInfo(
           { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
           partTimerProfile

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -458,14 +458,7 @@ const getSlackClient = (slackToken: string): SlackClient => {
   return new SlackClient(slackToken);
 };
 
-const getPartTimerProfile = (
-  userEmail: string
-): {
-  job: string;
-  lastName: string;
-  email: string;
-  managerEmails: string[];
-} => {
+const getPartTimerProfile = (userEmail: string): PartTimerProfile => {
   const { JOB_SHEET_URL } = getConfig();
   const sheet = SpreadsheetApp.openByUrl(JOB_SHEET_URL).getSheetByName("シート1");
   if (!sheet) throw new Error("SHEET is not defined");

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -634,15 +634,12 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
 const getInfoFromTitle = (title: string): { workingStyle: string; restStartTime: string; restEndTime: string } => {
   const workingStyleRegex = /【(.*?)】/;
   const matchResult = title.match(workingStyleRegex);
-  if (!matchResult) throw new Error("no workingStyle matching workingStyleRegex found");
-  const workingStyle = matchResult[0];
+  const workingStyle = matchResult ? matchResult[0] : "未設定";
 
   const restTimeRegex = /\(休憩: (.*?)\)/;
   const restTimeResult = title.match(restTimeRegex);
-  if (!restTimeResult) throw new Error("no restStartTime matching restStartTimeRegex found");
-  const restTime = restTimeResult[0];
-  const restStartTime = restTime.split("~")[0];
-  const restEndTime = restTime.split("~")[1];
+  const restStartTime = restTimeResult ? restTimeResult[0].split("~")[0] : "";
+  const restEndTime = restTimeResult ? restTimeResult[1].split("~")[0] : "";
 
   return { workingStyle, restStartTime, restEndTime };
 };

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -244,41 +244,43 @@ const getModificationInfos = (
   previousEventInfo: EventInfo;
   newEventInfo: EventInfo;
 }[] => {
-  const modificationInfos = sheetValues.map((row) => {
-    const title = row.title;
-    const date = format(row.date, "yyyy-MM-dd");
-    const startTime = format(row.startTime, "HH:mm");
-    const endTime = format(row.endTime, "HH:mm");
-    const newDate = format(row.newDate, "yyyy-MM-dd");
-    const newStartTime = format(row.newStartTime, "HH:mm");
-    const newEndTime = format(row.newEndTime, "HH:mm");
-    if (row.newRestStartTime === "" || row.newRestEndTime === "") {
-      const newRestStartTime = row.newRestStartTime as string;
-      const newRestEndTime = row.newRestEndTime as string;
-      const newWorkingStyle = row.newWorkingStyle;
-      if (newWorkingStyle === "") throw new Error("new working style is not defined");
-      const newTitle = createTitleFromEventInfo(
-        { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
-        partTimerProfile
-      );
-      return {
-        previousEventInfo: { title, date, startTime, endTime },
-        newEventInfo: { title: newTitle, date: newDate, startTime: newStartTime, endTime: newEndTime },
-      };
-    } else {
-      const newRestStartTime = format(row.newRestStartTime as Date, "HH:mm");
-      const newRestEndTime = format(row.newRestEndTime as Date, "HH:mm");
-      const newWorkingStyle = row.newWorkingStyle;
-      const newTitle = createTitleFromEventInfo(
-        { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
-        partTimerProfile
-      );
-      return {
-        previousEventInfo: { title, date, startTime, endTime },
-        newEventInfo: { title: newTitle, date: newDate, startTime: newStartTime, endTime: newEndTime },
-      };
-    }
-  });
+  const modificationInfos = sheetValues
+    .filter((row) => !row.deletionFlag)
+    .map((row) => {
+      const title = row.title;
+      const date = format(row.date, "yyyy-MM-dd");
+      const startTime = format(row.startTime, "HH:mm");
+      const endTime = format(row.endTime, "HH:mm");
+      const newDate = format(row.newDate, "yyyy-MM-dd");
+      const newStartTime = format(row.newStartTime, "HH:mm");
+      const newEndTime = format(row.newEndTime, "HH:mm");
+      if (row.newRestStartTime === "" || row.newRestEndTime === "") {
+        const newRestStartTime = row.newRestStartTime as string;
+        const newRestEndTime = row.newRestEndTime as string;
+        const newWorkingStyle = row.newWorkingStyle;
+        if (newWorkingStyle === "") throw new Error("new working style is not defined");
+        const newTitle = createTitleFromEventInfo(
+          { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
+          partTimerProfile
+        );
+        return {
+          previousEventInfo: { title, date, startTime, endTime },
+          newEventInfo: { title: newTitle, date: newDate, startTime: newStartTime, endTime: newEndTime },
+        };
+      } else {
+        const newRestStartTime = format(row.newRestStartTime as Date, "HH:mm");
+        const newRestEndTime = format(row.newRestEndTime as Date, "HH:mm");
+        const newWorkingStyle = row.newWorkingStyle;
+        const newTitle = createTitleFromEventInfo(
+          { restStartTime: newRestStartTime, restEndTime: newRestEndTime, workingStyle: newWorkingStyle },
+          partTimerProfile
+        );
+        return {
+          previousEventInfo: { title, date, startTime, endTime },
+          newEventInfo: { title: newTitle, date: newDate, startTime: newStartTime, endTime: newEndTime },
+        };
+      }
+    });
 
   return modificationInfos;
 };
@@ -298,13 +300,15 @@ const getDeletionInfos = (
     deletionFlag: boolean;
   }[]
 ): EventInfo[] => {
-  const deletionInfos = sheetValues.map((row) => {
-    const title = row.title;
-    const date = format(row.date, "yyyy-MM-dd");
-    const startTime = format(row.startTime, "HH:mm");
-    const endTime = format(row.endTime, "HH:mm");
-    return { title, date, startTime, endTime };
-  });
+  const deletionInfos = sheetValues
+    .filter((row) => row.deletionFlag)
+    .map((row) => {
+      const title = row.title;
+      const date = format(row.date, "yyyy-MM-dd");
+      const startTime = format(row.startTime, "HH:mm");
+      const endTime = format(row.endTime, "HH:mm");
+      return { title, date, startTime, endTime };
+    });
 
   return deletionInfos;
 };
@@ -320,10 +324,8 @@ export const callModificationAndDeletion = () => {
   const operationType: OperationType = "modificationAndDeletion";
   const sheetValues = getModificationAndDeletionSheetValues(sheet);
   const valuesForOperation = sheetValues.filter((row) => row.deletionFlag || row.newDate);
-  const modificationSheetValues = valuesForOperation.filter((row) => !row.deletionFlag);
-  const deletionSheetValues = valuesForOperation.filter((row) => row.deletionFlag);
-  const modificationInfos = getModificationInfos(modificationSheetValues, partTimerProfile);
-  const deletionInfos = getDeletionInfos(deletionSheetValues);
+  const modificationInfos = getModificationInfos(valuesForOperation, partTimerProfile);
+  const deletionInfos = getDeletionInfos(valuesForOperation);
 
   const payload = {
     apiId: "shift-changer",

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -520,14 +520,18 @@ const getPartTimerProfile = (
 };
 
 const createMessageFromEventInfo = (sheetValue: SheetValue) => {
-  const formattedDate = format(new Date(sheetValue.date), "MM/dd");
+  const date = format(new Date(sheetValue.date), "MM/dd");
+  const startTime = format(new Date(sheetValue.startTime), "HH:mm");
+  const endTime = format(new Date(sheetValue.endTime), "HH:mm");
   const workingStyle = sheetValue.workingStyle;
-  const restStartTime = sheetValue.restStartTime;
-  const restEndTime = sheetValue.restEndTime;
-  if (restStartTime === "" || restEndTime === "")
-    return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime}`;
-  else
-    return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime} (休憩: ${restStartTime}~${restEndTime})`;
+  console.log();
+  if (sheetValue.restStartTime === "" || sheetValue.restEndTime === "")
+    return `【${workingStyle}】 ${date} ${startTime}~${endTime}`;
+  else {
+    const restStartTime = format(new Date(sheetValue.restStartTime), "HH:mm");
+    const restEndTime = format(new Date(sheetValue.restEndTime), "HH:mm");
+    return `【${workingStyle}】 ${date} ${startTime}~${endTime} (休憩: ${restStartTime}~${restEndTime})`;
+  }
 };
 
 const createRegistrationMessage = (
@@ -648,16 +652,21 @@ const getManagerSlackIds = (managerEmails: string[], client: SlackClient): strin
   return managerSlackIds;
 };
 
-const getInfoFromTitle = (title: string): { workingStyle: string; restStartTime: string; restEndTime: string } => {
+const getInfoFromTitle = (
+  title: string
+): { workingStyle: string; restStartTime: Date | string; restEndTime: Date | string } => {
   const workingStyleRegex = /【(.*?)】/;
   const matchResult = title.match(workingStyleRegex);
-  const workingStyle = matchResult ? matchResult[0] : "未設定";
+  const workingStyle = matchResult ? matchResult[1] : "未設定";
 
   const restTimeRegex = /\(休憩: (.*?)\)/;
   const restTimeResult = title.match(restTimeRegex);
-  const restStartTime = restTimeResult ? restTimeResult[0].split("~")[0] : "";
-  const restEndTime = restTimeResult ? restTimeResult[1].split("~")[0] : "";
-
+  const restStartTime = restTimeResult
+    ? new Date(`${format(new Date(), "MM/dd")} ${restTimeResult[1].split("~")[0]}`)
+    : "";
+  const restEndTime = restTimeResult
+    ? new Date(`${format(new Date(), "MM/dd")} ${restTimeResult[1].split("~")[1]}`)
+    : "";
   return { workingStyle, restStartTime, restEndTime };
 };
 const slackIdToMention = (slackId: string) => `<@${slackId}>`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -522,7 +522,12 @@ const getPartTimerProfile = (
 const createMessageFromEventInfo = (sheetValue: SheetValue) => {
   const formattedDate = format(new Date(sheetValue.date), "MM/dd");
   const workingStyle = sheetValue.workingStyle;
-  return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime}`;
+  const restStartTime = sheetValue.restStartTime;
+  const restEndTime = sheetValue.restEndTime;
+  if (restStartTime === "" || restEndTime === "")
+    return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime}`;
+  else
+    return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime} (休憩: ${restStartTime}~${restEndTime})`;
 };
 
 const createRegistrationMessage = (

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -522,16 +522,7 @@ const getPartTimerProfile = (
   return partTimerProfile;
 };
 
-const createMessageFromEventInfo = (eventInfo: EventInfo) => {
-  const formattedDate = format(new Date(eventInfo.date), "MM/dd");
-  const workingStyleRegex = /【(.*?)】/;
-  const matchResult = eventInfo.title.match(workingStyleRegex);
-  if (!matchResult) throw new Error("no workingStyle matching workingStyleRegex found");
-  const workingStyle = matchResult[0];
-  return `${workingStyle} ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
-};
-
-const createMessageFromEventInfo2 = (sheetValue: {
+const createMessageFromEventInfo = (sheetValue: {
   date: Date;
   startTime: Date;
   endTime: Date;
@@ -556,7 +547,7 @@ const createRegistrationMessage = (
   comment: string,
   userEmail: string
 ): string => {
-  const messages = sheetValues.map(createMessageFromEventInfo2);
+  const messages = sheetValues.map(createMessageFromEventInfo);
   const { job, lastName } = getPartTimerProfile(userEmail);
   const messageTitle = `${job}${lastName}さんの以下の予定が追加されました。`;
   return comment
@@ -583,7 +574,7 @@ const createDeletionMessage = (
 ): string | undefined => {
   const messages = deletionSheetValues.map((sheetValue) => {
     const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
-    createMessageFromEventInfo2({
+    createMessageFromEventInfo({
       date: sheetValue.date,
       startTime: sheetValue.startTime,
       endTime: sheetValue.endTime,
@@ -641,9 +632,9 @@ const createModificationMessage = (
 
   const messages = modificationSheetInfos.map(({ previousEventInfo, newEventInfo }) => {
     return `---
-    ${createMessageFromEventInfo2(previousEventInfo)}\n
+    ${createMessageFromEventInfo(previousEventInfo)}\n
     ↓\n
-    ${createMessageFromEventInfo2(newEventInfo)}`;
+    ${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;
   const { job, lastName } = getPartTimerProfile(userEmail);

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -423,17 +423,17 @@ const createTitleFromEventInfo = (
   },
   userEmail: string
 ): string => {
-  const { job, name } = getPartTimerProfile(userEmail);
+  const { job, lastName } = getPartTimerProfile(userEmail);
 
   const restStartTime = eventInfo.restStartTime;
   const restEndTime = eventInfo.restEndTime;
   const workingStyle = eventInfo.workingStyle;
 
   if (restStartTime === "" || restEndTime === "") {
-    const title = `【${workingStyle}】${job}${name}さん`;
+    const title = `【${workingStyle}】${job}${lastName}さん`;
     return title;
   } else {
-    const title = `【${workingStyle}】${job}${name}さん (休憩: ${restStartTime}~${restEndTime})`;
+    const title = `【${workingStyle}】${job}${lastName}さん (休憩: ${restStartTime}~${restEndTime})`;
     return title;
   }
 };
@@ -446,7 +446,7 @@ const getPartTimerProfile = (
   userEmail: string
 ): {
   job: string;
-  name: string;
+  lastName: string;
   email: string;
   managerEmails: string[];
 } => {
@@ -458,7 +458,8 @@ const getPartTimerProfile = (
     .getValues()
     .map((row) => ({
       job: row[0] as string,
-      name: row[1] as string,
+      // \u3000は全角空白
+      lastName: row[1].split(/(\s|\u3000)+/)[0] as string,
       email: row[2] as string,
       managerEmails: row[3] === "" ? [] : (row[3] as string).replaceAll(/\s/g, "").split(","),
     }));
@@ -482,8 +483,8 @@ const createMessageFromEventInfo = (eventInfo: EventInfo) => {
 
 const createRegistrationMessage = (registrationInfos: EventInfo[], comment: string, userEmail: string): string => {
   const messages = registrationInfos.map(createMessageFromEventInfo);
-  const { job, name } = getPartTimerProfile(userEmail);
-  const messageTitle = `${job}${name}さんの以下の予定が追加されました。`;
+  const { job, lastName } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${lastName}さんの以下の予定が追加されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;
@@ -492,8 +493,8 @@ const createRegistrationMessage = (registrationInfos: EventInfo[], comment: stri
 const createDeletionMessage = (deletionInfos: EventInfo[], comment: string, userEmail: string): string | undefined => {
   const messages = deletionInfos.map(createMessageFromEventInfo);
   if (messages.length == 0) return;
-  const { job, name } = getPartTimerProfile(userEmail);
-  const messageTitle = `${job}${name}さんの以下の予定が削除されました。`;
+  const { job, lastName } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${lastName}さんの以下の予定が削除されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;
@@ -514,8 +515,8 @@ const createModificationMessage = (
     ${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;
-  const { job, name } = getPartTimerProfile(userEmail);
-  const messageTitle = `${job}${name}さんの以下の予定が変更されました。`;
+  const { job, lastName } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${lastName}さんの以下の予定が変更されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -501,8 +501,10 @@ const createModificationMessage = (
   comment: string
 ): string | undefined => {
   const messages = modificationInfos.map(({ previousEventInfo, newEventInfo }) => {
-    return `${createMessageFromEventInfo(previousEventInfo)}\n\
-    → ${createMessageFromEventInfo(newEventInfo)}`;
+    return `---
+    ${createMessageFromEventInfo(previousEventInfo)}\n\
+    ↓\n\
+    ${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;
   const messageTitle = "以下の予定が変更されました。";

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -524,7 +524,6 @@ const createMessageFromEventInfo = (sheetValue: SheetValue) => {
   const startTime = format(new Date(sheetValue.startTime), "HH:mm");
   const endTime = format(new Date(sheetValue.endTime), "HH:mm");
   const workingStyle = sheetValue.workingStyle;
-  console.log();
   if (sheetValue.restStartTime === "" || sheetValue.restEndTime === "")
     return `【${workingStyle}】 ${date} ${startTime}~${endTime}`;
   else {

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -336,7 +336,7 @@ export const callModificationAndDeletion = () => {
   if (modificationMessageToNotify)
     postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationMessageToNotify, userEmail);
 
-  const deletionMessageToNotify = createDeletionMessage(deletionInfos, comment, userEmail);
+  const deletionMessageToNotify = createDeletionMessage(deletionSheetValues, comment, userEmail);
   if (deletionMessageToNotify)
     postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, deletionMessageToNotify, userEmail);
 };
@@ -564,8 +564,34 @@ const createRegistrationMessage = (
     : `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createDeletionMessage = (deletionInfos: EventInfo[], comment: string, userEmail: string): string | undefined => {
-  const messages = deletionInfos.map(createMessageFromEventInfo);
+const createDeletionMessage = (
+  deletionSheetValues: {
+    title: string;
+    date: Date;
+    startTime: Date;
+    endTime: Date;
+    newDate: Date;
+    newStartTime: Date;
+    newEndTime: Date;
+    newRestStartTime: Date | string;
+    newRestEndTime: Date | string;
+    newWorkingStyle: string;
+    deletionFlag: boolean;
+  }[],
+  comment: string,
+  userEmail: string
+): string | undefined => {
+  const messages = deletionSheetValues.map((sheetValue) => {
+    const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
+    createMessageFromEventInfo2({
+      date: sheetValue.date,
+      startTime: sheetValue.startTime,
+      endTime: sheetValue.endTime,
+      restStartTime,
+      restEndTime,
+      workingStyle,
+    });
+  });
   if (messages.length == 0) return;
   const { job, lastName } = getPartTimerProfile(userEmail);
   const messageTitle = `${job}${lastName}さんの以下の予定が削除されました。`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -565,7 +565,7 @@ const createDeletionMessage = (
 ): string | undefined => {
   const messages = deletionSheetValues.map((sheetValue) => {
     const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
-    createMessageFromEventInfo({
+    return createMessageFromEventInfo({
       date: sheetValue.date,
       startTime: sheetValue.startTime,
       endTime: sheetValue.endTime,

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -5,14 +5,6 @@ import { EventInfo } from "./shift-changer-api";
 
 type SheetType = "registration" | "modificationAndDeletion";
 type OperationType = "registration" | "modificationAndDeletion" | "showEvents";
-type SheetValue = {
-  date: Date;
-  startTime: Date;
-  endTime: Date;
-  restStartTime: Date | string;
-  restEndTime: Date | string;
-  workingStyle: string;
-};
 type PartTimerProfile = {
   job: string;
   lastName: string;
@@ -405,7 +397,16 @@ const getSheet = (sheetType: SheetType, spreadsheetUrl: string): GoogleAppsScrip
   return sheet;
 };
 
-const getRegistrationSheetValues = (sheet: GoogleAppsScript.Spreadsheet.Sheet): SheetValue[] => {
+const getRegistrationSheetValues = (
+  sheet: GoogleAppsScript.Spreadsheet.Sheet
+): {
+  date: Date;
+  startTime: Date;
+  endTime: Date;
+  restStartTime: Date | string;
+  restEndTime: Date | string;
+  workingStyle: string;
+}[] => {
   const sheetValues = sheet
     .getRange(5, 1, sheet.getLastRow() - 4, sheet.getLastColumn())
     .getValues()
@@ -434,7 +435,17 @@ const getRegistrationSheetValues = (sheet: GoogleAppsScript.Spreadsheet.Sheet): 
   return sheetValues;
 };
 
-const getRegistrationInfos = (sheetValues: SheetValue[], partTimerProfile: PartTimerProfile): EventInfo[] => {
+const getRegistrationInfos = (
+  sheetValues: {
+    date: Date;
+    startTime: Date;
+    endTime: Date;
+    restStartTime: Date | string;
+    restEndTime: Date | string;
+    workingStyle: string;
+  }[],
+  partTimerProfile: PartTimerProfile
+): EventInfo[] => {
   const registrationInfos = sheetValues.map((row) => {
     const date = format(row.date, "yyyy-MM-dd");
     const startTime = format(row.startTime, "HH:mm");

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -13,6 +13,12 @@ type SheetValue = {
   restEndTime: Date | string;
   workingStyle: string;
 };
+type PartTimerProfile = {
+  job: string;
+  lastName: string;
+  email: string;
+  managerEmails: string[];
+};
 
 export const onOpen = () => {
   const ui = SpreadsheetApp.getUi();
@@ -242,12 +248,7 @@ const getModificationInfos = (
     newWorkingStyle: string;
     deletionFlag: boolean;
   }[],
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): {
   previousEventInfo: EventInfo;
   newEventInfo: EventInfo;
@@ -433,15 +434,7 @@ const getRegistrationSheetValues = (sheet: GoogleAppsScript.Spreadsheet.Sheet): 
   return sheetValues;
 };
 
-const getRegistrationInfos = (
-  sheetValues: SheetValue[],
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
-): EventInfo[] => {
+const getRegistrationInfos = (sheetValues: SheetValue[], partTimerProfile: PartTimerProfile): EventInfo[] => {
   const registrationInfos = sheetValues.map((row) => {
     const date = format(row.date, "yyyy-MM-dd");
     const startTime = format(row.startTime, "HH:mm");
@@ -475,12 +468,7 @@ const createTitleFromEventInfo = (
     restEndTime: string;
     workingStyle: string;
   },
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): string => {
   const { job, lastName } = partTimerProfile;
 
@@ -540,12 +528,7 @@ const createMessageFromEventInfo = (sheetValue: SheetValue) => {
 const createRegistrationMessage = (
   sheetValues: SheetValue[],
   comment: string,
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): string => {
   const messages = sheetValues.map(createMessageFromEventInfo);
   const { job, lastName } = partTimerProfile;
@@ -570,12 +553,7 @@ const createDeletionMessage = (
     deletionFlag: boolean;
   }[],
   comment: string,
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): string | undefined => {
   const messages = deletionSheetValues.map((sheetValue) => {
     const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
@@ -611,12 +589,7 @@ const createModificationMessage = (
     deletionFlag: boolean;
   }[],
   comment: string,
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ): string | undefined => {
   const modificationSheetInfos = modificationSheetValues.map((sheetValue) => {
     const { workingStyle, restStartTime, restEndTime } = getInfoFromTitle(sheetValue.title);
@@ -688,12 +661,7 @@ const postMessageToSlackChannel = (
   client: SlackClient,
   slackChannelToPost: string,
   messageToNotify: string,
-  partTimerProfile: {
-    job: string;
-    lastName: string;
-    email: string;
-    managerEmails: string[];
-  }
+  partTimerProfile: PartTimerProfile
 ) => {
   const { HR_MANAGER_SLACK_ID } = getConfig();
   const { managerEmails } = partTimerProfile;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -5,6 +5,14 @@ import { EventInfo } from "./shift-changer-api";
 
 type SheetType = "registration" | "modificationAndDeletion";
 type OperationType = "registration" | "modificationAndDeletion" | "showEvents";
+type SheetValue = {
+  date: Date;
+  startTime: Date;
+  endTime: Date;
+  restStartTime: Date | string;
+  restEndTime: Date | string;
+  workingStyle: string;
+};
 
 export const onOpen = () => {
   const ui = SpreadsheetApp.getUi();
@@ -389,16 +397,7 @@ const getSheet = (sheetType: SheetType, spreadsheetUrl: string): GoogleAppsScrip
   return sheet;
 };
 
-const getRegistrationSheetValues = (
-  sheet: GoogleAppsScript.Spreadsheet.Sheet
-): {
-  date: Date;
-  startTime: Date;
-  endTime: Date;
-  restStartTime: Date | string;
-  restEndTime: Date | string;
-  workingStyle: string;
-}[] => {
+const getRegistrationSheetValues = (sheet: GoogleAppsScript.Spreadsheet.Sheet): SheetValue[] => {
   const sheetValues = sheet
     .getRange(5, 1, sheet.getLastRow() - 4, sheet.getLastColumn())
     .getValues()
@@ -427,17 +426,7 @@ const getRegistrationSheetValues = (
   return sheetValues;
 };
 
-const getRegistrationInfos = (
-  sheetValues: {
-    date: Date;
-    startTime: Date;
-    endTime: Date;
-    restStartTime: Date | string;
-    restEndTime: Date | string;
-    workingStyle: string;
-  }[],
-  userEmail: string
-): EventInfo[] => {
+const getRegistrationInfos = (sheetValues: SheetValue[], userEmail: string): EventInfo[] => {
   const registrationInfos = sheetValues.map((row) => {
     const date = format(row.date, "yyyy-MM-dd");
     const startTime = format(row.startTime, "HH:mm");
@@ -522,31 +511,13 @@ const getPartTimerProfile = (
   return partTimerProfile;
 };
 
-const createMessageFromEventInfo = (sheetValue: {
-  date: Date;
-  startTime: Date;
-  endTime: Date;
-  restStartTime: Date | string;
-  restEndTime: Date | string;
-  workingStyle: string;
-}) => {
+const createMessageFromEventInfo = (sheetValue: SheetValue) => {
   const formattedDate = format(new Date(sheetValue.date), "MM/dd");
   const workingStyle = sheetValue.workingStyle;
   return `${workingStyle} ${formattedDate} ${sheetValue.startTime}~${sheetValue.endTime}`;
 };
 
-const createRegistrationMessage = (
-  sheetValues: {
-    date: Date;
-    startTime: Date;
-    endTime: Date;
-    restStartTime: Date | string;
-    restEndTime: Date | string;
-    workingStyle: string;
-  }[],
-  comment: string,
-  userEmail: string
-): string => {
+const createRegistrationMessage = (sheetValues: SheetValue[], comment: string, userEmail: string): string => {
   const messages = sheetValues.map(createMessageFromEventInfo);
   const { job, lastName } = getPartTimerProfile(userEmail);
   const messageTitle = `${job}${lastName}さんの以下の予定が追加されました。`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -161,7 +161,7 @@ export const callRegistration = () => {
   };
   const { API_URL, SLACK_CHANNEL_TO_POST } = getConfig();
   UrlFetchApp.fetch(API_URL, options);
-  const messageToNotify = createRegistrationMessage(registrationInfos, comment);
+  const messageToNotify = createRegistrationMessage(registrationInfos, comment, userEmail);
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, messageToNotify, userEmail);
 };
 
@@ -333,11 +333,11 @@ export const callModificationAndDeletion = () => {
   const { API_URL, SLACK_CHANNEL_TO_POST } = getConfig();
   UrlFetchApp.fetch(API_URL, options);
 
-  const modificationMessageToNotify = createModificationMessage(modificationInfos, comment);
+  const modificationMessageToNotify = createModificationMessage(modificationInfos, comment, userEmail);
   if (modificationMessageToNotify)
     postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationMessageToNotify, userEmail);
 
-  const deletionMessageToNotify = createDeletionMessage(deletionInfos, comment);
+  const deletionMessageToNotify = createDeletionMessage(deletionInfos, comment, userEmail);
   if (deletionMessageToNotify)
     postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, deletionMessageToNotify, userEmail);
 };
@@ -480,18 +480,20 @@ const createMessageFromEventInfo = (eventInfo: EventInfo) => {
   return `${workingStyle}: ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
 };
 
-const createRegistrationMessage = (registrationInfos: EventInfo[], comment: string): string => {
+const createRegistrationMessage = (registrationInfos: EventInfo[], comment: string, userEmail: string): string => {
   const messages = registrationInfos.map(createMessageFromEventInfo);
-  const messageTitle = "以下の予定が追加されました。";
+  const { job, name } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${name}さんの以下の予定が追加されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createDeletionMessage = (deletionInfos: EventInfo[], comment: string): string | undefined => {
+const createDeletionMessage = (deletionInfos: EventInfo[], comment: string, userEmail: string): string | undefined => {
   const messages = deletionInfos.map(createMessageFromEventInfo);
   if (messages.length == 0) return;
-  const messageTitle = "以下の予定が削除されました。";
+  const { job, name } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${name}さんの以下の予定が削除されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;
@@ -502,7 +504,8 @@ const createModificationMessage = (
     previousEventInfo: EventInfo;
     newEventInfo: EventInfo;
   }[],
-  comment: string
+  comment: string,
+  userEmail: string
 ): string | undefined => {
   const messages = modificationInfos.map(({ previousEventInfo, newEventInfo }) => {
     return `---
@@ -511,7 +514,8 @@ const createModificationMessage = (
     ${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;
-  const messageTitle = "以下の予定が変更されました。";
+  const { job, name } = getPartTimerProfile(userEmail);
+  const messageTitle = `${job}${name}さんの以下の予定が変更されました。`;
   return comment
     ? `${messageTitle}\n${messages.join("\n")}\n\nコメント: ${comment}`
     : `${messageTitle}\n${messages.join("\n")}`;

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -430,10 +430,10 @@ const createTitleFromEventInfo = (
   const workingStyle = eventInfo.workingStyle;
 
   if (restStartTime === "" || restEndTime === "") {
-    const title = `【${workingStyle}】${job}: ${name}さん`;
+    const title = `【${workingStyle}】${job}${name}さん`;
     return title;
   } else {
-    const title = `【${workingStyle}】${job}: ${name}さん (休憩: ${restStartTime}~${restEndTime})`;
+    const title = `【${workingStyle}】${job}${name}さん (休憩: ${restStartTime}~${restEndTime})`;
     return title;
   }
 };
@@ -473,7 +473,11 @@ const getPartTimerProfile = (
 
 const createMessageFromEventInfo = (eventInfo: EventInfo) => {
   const formattedDate = format(new Date(eventInfo.date), "MM/dd");
-  return `${eventInfo.title}: ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
+  const workingStyleRegex = /【(.*?)】/;
+  const matchResult = eventInfo.title.match(workingStyleRegex);
+  if (!matchResult) throw new Error("no workingStyle matching workingStyleRegex found");
+  const workingStyle = matchResult[0];
+  return `${workingStyle}: ${formattedDate} ${eventInfo.startTime}~${eventInfo.endTime}`;
 };
 
 const createRegistrationMessage = (registrationInfos: EventInfo[], comment: string): string => {


### PR DESCRIPTION
予定に共通な項目 `Type` `Who` を最初にまとめて表示するようにした。また、名前はフルネームではなく名字のみにした。
また、`変更` の際は変更前と後の予定を縦に並べ、 予定の間に区切り `---` を入れた。

以下が出力例。

`登録`
```
Biz戸倉さんの以下の予定が追加されました。
【リモート】 07/25 12:00~17:00 (休憩: 14:00-15:00)
【リモート】 07/27 13:00~16:00
```

`削除`
```
Biz戸倉さんの以下の予定が削除されました。
【リモート】 07/25 12:00~17:00
【リモート】 07/27 13:00~16:00
```

`変更`
```
Tech大類さんの以下の予定が変更されました。
---
【リモート】 07/25 09:00~12:00
↓
【リモート】 07/24 13:00~16:00 //←差分を太字にする
---
【出社】 07/28 10:00~14:00
↓
【出社】 07/28 13:00~17:00  (休憩: 14:00-15:00)
```

[参考Trello](https://trello.com/c/RGu7tinA)
