### PR TITLE
fix: 予定表示で日付を指定しない場合に発生するnoEventsエラーの解消

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -75,10 +75,11 @@ export const insertModificationAndDeletionSheet = () => {
   const commentCell = sheet.getRange("A2");
   commentCell.setBackground("#f0f8ff");
 
-  const description2 = "本日以降の日付を入力してください。指定した日付から一週間後までの予定が表示されます。";
+  const description2 = "本日以降の日付を下の色付きセルに記入してください。一週間後までの予定が表示されます。";
   sheet.getRange("A4").setValue(description2).setFontWeight("bold");
-
-  sheet.getRange("A5").setValue(today);
+  const dateCell = sheet.getRange("A5");
+  dateCell.setValue(today);
+  dateCell.setBackground("#f0f8ff");
 
   const description3 = "【予定一覧】";
   sheet.getRange("A7").setValue(description3).setFontWeight("bold");
@@ -104,7 +105,6 @@ export const insertModificationAndDeletionSheet = () => {
   ];
   sheet.getRange(8, 1, 1, header.length).setValues([header]).setFontWeight("bold");
 
-  const dateCell = sheet.getRange("A5");
   const dateCells = sheet.getRange("E9:E1000");
   const dateRule = SpreadsheetApp.newDataValidation()
     .requireDateOnOrAfter(new Date())

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -349,6 +349,7 @@ export const callShowEvents = () => {
   const sheet = getSheet(sheetType, spreadsheetUrl);
   const operationType: OperationType = "showEvents";
   const startDate: Date = sheet.getRange("A5").getValue();
+  if (!startDate) throw new Error("specify date");
 
   const payload = {
     apiId: "shift-changer",

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -78,6 +78,8 @@ export const insertModificationAndDeletionSheet = () => {
   const description2 = "本日以降の日付を入力してください。指定した日付から一週間後までの予定が表示されます。";
   sheet.getRange("A4").setValue(description2).setFontWeight("bold");
 
+  sheet.getRange("A5").setValue(today);
+
   const description3 = "【予定一覧】";
   sheet.getRange("A7").setValue(description3).setFontWeight("bold");
 

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -349,7 +349,7 @@ export const callShowEvents = () => {
   const sheet = getSheet(sheetType, spreadsheetUrl);
   const operationType: OperationType = "showEvents";
   const startDate: Date = sheet.getRange("A5").getValue();
-  if (!startDate) throw new Error("specify date");
+  if (!startDate) throw new Error("日付を指定してください。");
 
   const payload = {
     apiId: "shift-changer",


### PR DESCRIPTION
[参考Trello](https://trello.com/c/Gc7y910C)

利用者が予定を表示するとき日付の指定を忘れると、`noEvents` エラーが出てしまう。

以下の変更を加えた。
- 日付が空の場合は`specify date` エラーを出す
- シート挿入時に、デフォルトで今日の日付をセットする
- 日付指定のセルも色付きにする