### PR TITLE
modificationMessageとdeletionMessageをまとめて通知

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -340,16 +340,13 @@ export const callModificationAndDeletion = () => {
   const { API_URL, SLACK_CHANNEL_TO_POST } = getConfig();
   UrlFetchApp.fetch(API_URL, options);
 
-  const modificationMessageToNotify = createModificationMessage(modificationInfos, partTimerProfile)
-    ? `${createModificationMessage(modificationInfos, partTimerProfile)}\n---\n`
-    : "";
-  const deletionMessageToNotify = createDeletionMessage(deletionInfos, partTimerProfile)
-    ? `${createDeletionMessage(deletionInfos, partTimerProfile)}\n---\n`
-    : "";
-
-  const modificationAndDeletionMessageToNotify = comment
-    ? `${modificationMessageToNotify}${deletionMessageToNotify}コメント: ${comment}`
-    : `${modificationMessageToNotify}${deletionMessageToNotify}`;
+  const modificationAndDeletionMessageToNotify = [
+    createModificationMessage(modificationInfos, partTimerProfile),
+    createDeletionMessage(deletionInfos, partTimerProfile),
+    comment ? `コメント: ${comment}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n---\n");
 
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationAndDeletionMessageToNotify, partTimerProfile);
 };

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -520,7 +520,7 @@ const createModificationMessage = (
   if (messages.length == 0) return;
   const { job, lastName } = partTimerProfile;
   const messageTitle = `${job}${lastName}さんの以下の予定が変更されました。`;
-  return `${messageTitle}\n${messages.join("\n")}`;
+  return `${messageTitle}\n${messages.join("\n\n")}`;
 };
 
 const getManagerSlackIds = (managerEmails: string[], client: SlackClient): string[] => {

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -341,10 +341,10 @@ export const callModificationAndDeletion = () => {
   UrlFetchApp.fetch(API_URL, options);
 
   const modificationMessageToNotify = createModificationMessage(modificationInfos, partTimerProfile)
-    ? `${createModificationMessage(modificationInfos, partTimerProfile)}\n\n`
+    ? `${createModificationMessage(modificationInfos, partTimerProfile)}\n---\n`
     : "";
   const deletionMessageToNotify = createDeletionMessage(deletionInfos, partTimerProfile)
-    ? `${createDeletionMessage(deletionInfos, partTimerProfile)}\n\n`
+    ? `${createDeletionMessage(deletionInfos, partTimerProfile)}\n---\n`
     : "";
 
   const modificationAndDeletionMessageToNotify = comment
@@ -518,10 +518,7 @@ const createModificationMessage = (
   partTimerProfile: PartTimerProfile
 ): string | undefined => {
   const messages = modificationInfos.map(({ previousEventInfo, newEventInfo }) => {
-    return `---
-    ${createMessageFromEventInfo(previousEventInfo)}\n
-    ↓\n
-    ${createMessageFromEventInfo(newEventInfo)}`;
+    return `${createMessageFromEventInfo(previousEventInfo)}\n↓\n${createMessageFromEventInfo(newEventInfo)}`;
   });
   if (messages.length == 0) return;
   const { job, lastName } = partTimerProfile;


### PR DESCRIPTION
今までのシフト変更ツールでは、変更・削除シートで変更情報と削除情報を記入し提出すると、変更 / 削除で分かれて2回投稿が行われる。
2回連続で投稿することで、2回目の投稿時にslackの429エラーが出て投稿できないことがあったので、一度にまとめて投稿したい。

[参考Trello](https://trello.com/c/rQVRkPlw)