### PR TITLE
fix:作成日と提出する日付がズレていると登録できない事例を直した

### DIFF
--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -36,9 +36,9 @@ export const onOpen = () => {
 
 export const insertRegistrationSheet = () => {
   const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  const today = format(new Date(), "yyyy-MM-dd");
-  const sheet = spreadsheet.insertSheet(`${today}-登録`, 0);
-  sheet.addDeveloperMetadata(`${today}-registration`);
+  // const today = format(new Date(), "yyyy-MM-dd");
+  const sheet = spreadsheet.insertSheet(`登録`, 0);
+  sheet.addDeveloperMetadata(`today-registration`);
 
   const description1 = "コメント欄 (下の色付きセルに記入してください)";
   sheet.getRange("A1").setValue(description1).setFontWeight("bold");
@@ -73,8 +73,8 @@ export const insertRegistrationSheet = () => {
 export const insertModificationAndDeletionSheet = () => {
   const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
   const today = format(new Date(), "yyyy-MM-dd");
-  const sheet = spreadsheet.insertSheet(`${today}-変更・削除`, 0);
-  sheet.addDeveloperMetadata(`${today}-modificationAndDeletion`);
+  const sheet = spreadsheet.insertSheet(`変更・削除`, 0);
+  sheet.addDeveloperMetadata(`today-modificationAndDeletion`);
 
   const description1 = "コメント欄 (下の色付きセルに記入してください)";
   sheet.getRange("A1").setValue(description1).setFontWeight("bold");
@@ -389,10 +389,10 @@ export const callShowEvents = () => {
 };
 
 const getSheet = (sheetType: SheetType, spreadsheetUrl: string): GoogleAppsScript.Spreadsheet.Sheet => {
-  const today = format(new Date(), "yyyy-MM-dd");
+  //const today = format(new Date(), "yyyy-MM-dd");
   const sheet = SpreadsheetApp.openByUrl(spreadsheetUrl)
     .getSheets()
-    .find((sheet) => sheet.getDeveloperMetadata().some((metaData) => metaData.getKey() === `${today}-${sheetType}`));
+    .find((sheet) => sheet.getDeveloperMetadata().some((metaData) => metaData.getKey() === `today-${sheetType}`));
 
   if (!sheet) throw new Error("SHEET is not defined");
 

--- a/hisyonosuke/src/shift-changer/shift-changer.ts
+++ b/hisyonosuke/src/shift-changer/shift-changer.ts
@@ -72,7 +72,7 @@ export const insertRegistrationSheet = () => {
 
 export const insertModificationAndDeletionSheet = () => {
   const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  const today = format(new Date(), "yyyy-MM-dd");
+  //const today = format(new Date(), "yyyy-MM-dd");
   const sheet = spreadsheet.insertSheet(`変更・削除`, 0);
   sheet.addDeveloperMetadata(`today-modificationAndDeletion`);
 
@@ -84,7 +84,7 @@ export const insertModificationAndDeletionSheet = () => {
   const description2 = "本日以降の日付を下の色付きセルに記入してください。一週間後までの予定が表示されます。";
   sheet.getRange("A4").setValue(description2).setFontWeight("bold");
   const dateCell = sheet.getRange("A5");
-  dateCell.setValue(today);
+  //dateCell.setValue(today);
   dateCell.setBackground("#f0f8ff");
 
   const description3 = "【予定一覧】";


### PR DESCRIPTION
metadataの値がシートの作成日がはいっていたため日付をまたいだ際に提出を押すとファイルが見つからないことがあったそれを修正した。そのシートを何度も作成するのではなく使いまわしたいことも目的である。
具体的な修正
- metadataの値がシートの作成日だったのを消去し`today-${sheetType}`の形に変更
- 作成される変更・消去シートを使い回せるようにセル`A5`の値にデフォルトで入っていた作成日の日付を設定する処理を消去。
今後やりたいこと
- 追加を押したら入力された要素を消去するコードを追加する。
   ↑いちいち消去して書き込むとコードも長くなるのでコピー用のシートを作成してそれをコピーするのもありかも??
