### PR TITLE
chore: remove gha for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,27 @@
 name: Deploy
 
 on:
-    push:
-        branches:
-            - "main"
-        paths:
-            - attendance-manager/**
-            - .github/**
-            - "!**.md"
-    workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    paths:
+      - attendance-manager/**
+      - .github/**
+      - "!**.md"
+  workflow_dispatch:
 
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/cache@v3
-              with:
-                  key: v1-${{ hashFiles('yarn.lock') }}-${{ github.sha }}
-                  path: |
-                      node_modules
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-            - run: yarn
-            - run: yarn run buildpush:prod
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          key: v1-${{ hashFiles('yarn.lock') }}-${{ github.sha }}
+          path: |
+            node_modules
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn
+      - run: yarn run buildpush:prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,17 +24,4 @@ jobs:
               with:
                   node-version: 18
             - run: yarn
-            - run: yarn workspace attendance-manager build
-            - run: cp attendance-manager/appsscript.json attendance-manager/build/appsscript.json
-            - uses: daikikatsuragawa/clasp-action@v1.1.0
-              with:
-                  accessToken: ${{ secrets.ACCESS_TOKEN }}
-                  idToken: ${{ secrets.ID_TOKEN }}
-                  refreshToken: ${{ secrets.REFRESH_TOKEN }}
-                  clientId: ${{ secrets.CLIENT_ID }}
-                  clientSecret: ${{ secrets.CLIENT_SECRET }}
-                  scriptId: ${{ secrets.SCRIPT_ID }}
-                  command: "deploy"
-                  deployId: ${{ secrets.DEPLOY_ID }}
-                  rootDir: "attendance-manager/build"
-                  description: ${{ github.sha }}
+            - run: yarn run buildpush:prod

--- a/attendance-manager/package.json
+++ b/attendance-manager/package.json
@@ -8,9 +8,9 @@
     "open:prod": "cross-env clasp_config_project=.clasp.prod.json yarn clasp open",
     "open:dev": "cross-env clasp_config_project=.clasp.dev.json yarn clasp open",
     "test": "jest",
-    "build": "yarn webpack",
-    "buildpush:prod": "yarn webpack && cross-env clasp_config_project=.clasp.prod.json clasp push --force",
-    "buildpush:dev": " yarn webpack && cross-env clasp_config_project=.clasp.dev.json clasp push --force",
+    "build": "yarn webpack && cp appsscript.json build/appsscript.json",
+    "buildpush:prod": "yarn run build && cross-env clasp_config_project=.clasp.prod.json clasp push --force",
+    "buildpush:dev": " yarn run build && cross-env clasp_config_project=.clasp.dev.json clasp push --force",
     "postinstall": "mkdir -p build && cp appsscript.json build/appsscript.json"
   },
   "dependencies": {


### PR DESCRIPTION
https://github.com/siiibo/hisyonosuke/pull/61 でGASをWeb Appとしてdeployする必要がなくなったので、clasp deployが絡むGHAのコードを削除し、buildpushのみ実行するよう変更した。