### PR TITLE
chore: devcontainer環境構築ファイルのfishの参照パスの変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"github-cli": "latest",
-		"fish": "latest"
+		"ghcr.io/meaningful-ooo/devcontainer-features/fish": "latest"
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],


### PR DESCRIPTION
このPRは、docker環境設定ファイルのエラーを解消しました。
少し前、absent-announce-botでも同じようなことが起こった。→https://github.com/siiibo/absent-announce-bot/pull/16
dockerの環境構築をする際に"fish": "latest"でレガシ機能はサポートされていません。というエラーが出てしまっていた。
その箇所の参照パスを変更することにより環境構築することができた。

変更前:`"fish": "latest"`→変更後:`"ghcr.io/meaningful-ooo/devcontainer-features/fish": "latest"`

[関連Notion](https://www.notion.so/siiibo/hisyonosuke-fish-75f3c6d2693c4438b9d53ee8379a42b9?pvs=4)