### PR TITLE
fix: 自動退勤システムのエラー解決

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -145,7 +145,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   ).match(
     (slackIds) => {
       const mentionIds = slackIds.map((slackId) => `<@${slackId}>`).join(", ");
-      const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください`;
+      const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください。`;
       const timeToPost = set(new Date(), { hours: 9, minutes: 0, seconds: 0 });
       const response = client.chat.scheduleMessage({
         channel: channelId,

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -136,10 +136,10 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   unClockedOutSlackIds.forEach((slackId) => {
     getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID).andThen((employeeId)=>{
       return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => {
-        console.info(slackId,":退勤打刻に成功しました");
+        console.info(`${slackId}:退勤打刻に成功しました`);
         return ok("ok");
       }).orElse(() => {
-        console.error(slackId,":退勤打刻に失敗しました");
+        console.error(`${slackId}:退勤打刻に失敗しました`);
         return err("err");
       });
     }).orElse(() => {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -145,7 +145,8 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
       });
   });
   const mentionIds = unClockedOutSlackIds.map((slackId) => `<@${slackId}>`).join(", ");
-
+  console.log(mentionIds);
+  
   const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください`;
   const timeToPost = set(new Date(), { hours: 9, minutes: 0, seconds: 0 });
   const response = client.chat.scheduleMessage({

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -88,7 +88,7 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
         return execAction(client, new Freee(), channelId, FREEE_COMPANY_ID, {
           message,
           userWorkStatus,
-          actionType
+          actionType,
         });
       })
       .match(
@@ -158,7 +158,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   const response = client.chat.scheduleMessage({
     channel: channelId,
     text: message,
-    post_at: getUnixTimeStampString(timeToPost)
+    post_at: getUnixTimeStampString(timeToPost),
   });
   if (!response.ok) {
     throw new Error(response.error);
@@ -209,7 +209,7 @@ function handleClockIn(
     company_id: FREEE_COMPANY_ID,
     type: "clock_in" as const,
     base_date: formatDate(clockInDate, "date"),
-    datetime: formatDate(clockInDate, "datetime")
+    datetime: formatDate(clockInDate, "datetime"),
   };
 
   return freee
@@ -257,7 +257,7 @@ function handleClockOut(
     company_id: FREEE_COMPANY_ID,
     type: "clock_out" as const,
     base_date: formatDate(clockOutBaseDate, "date"),
-    datetime: formatDate(clockOutDate, "datetime")
+    datetime: formatDate(clockOutDate, "datetime"),
   };
 
   return freee
@@ -302,9 +302,9 @@ function handleClockOutAndAddRemoteMemo(
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),
-            clock_out_at: formatDate(record.clock_out_at, "datetime")
+            clock_out_at: formatDate(record.clock_out_at, "datetime"),
           };
-        })
+        }),
       };
       return freee.updateWorkRecord(employeeId, targetDate, newWorkRecord);
     })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -138,14 +138,15 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     freee
       .setTimeClocks(employeeId.value, clockOutParams)
       .andThen(() => {
+        console.info(slackId,":退勤打刻に成功しました");
         return ok("ok");
       })
       .orElse(() => {
+        console.error(slackId,":退勤打刻に失敗しました");
         return err("error");
       });
   });
   const mentionIds = unClockedOutSlackIds.map((slackId) => `<@${slackId}>`).join(", ");
-  console.log(mentionIds);
 
   const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください`;
   const timeToPost = set(new Date(), { hours: 9, minutes: 0, seconds: 0 });

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -125,15 +125,15 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     return userStatus !== undefined && userStatus.workStatus !== "退勤済み";
   });
   if (unClockedOutSlackIds.length === 0) return;
-
+  const today= new Date();
   unClockedOutSlackIds.forEach((slackId) => {
     const employeeId = getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID);
     if (employeeId.isErr()) throw new Error(employeeId.error);
     const clockOutParams = {
       company_id: FREEE_COMPANY_ID,
       type: "clock_out" as const,
-      base_date: formatDate(new Date(), "date"),
-      datetime: formatDate(new Date(), "datetime"),
+      base_date: formatDate(today, "date"),
+      datetime: formatDate(today, "datetime"),
     };
     freee
       .setTimeClocks(employeeId.value, clockOutParams)
@@ -146,7 +146,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   });
   const mentionIds = unClockedOutSlackIds.map((slackId) => `<@${slackId}>`).join(", ");
   console.log(mentionIds);
-  
+
   const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください`;
   const timeToPost = set(new Date(), { hours: 9, minutes: 0, seconds: 0 });
   const response = client.chat.scheduleMessage({


### PR DESCRIPTION
#67 で本番環境で実験をした際にエラーが出てしまったそれを解決することを目的とする。

主要変更
- `setTimeClocks`に渡す引数の`base_date`が当日になってしまっていたため、前日の日付に変更。
 日付を跨いだ時の退勤は前日の日付が必須であるため:[ドキュメント](https://developer.freee.co.jp/reference/hr/reference#operations-tag-タイムレコーダー(打刻))

その他変更・追加内容
- 自動退勤された人のログを表示できるようにログを追加
- Result型を用いて例外処理を書くように変更

[関連Notion](https://www.notion.so/siiibo/30aca1d9edfc4b368b81f88d6cfb62c5?pvs=4)