### PR TITLE
feat: 自動退勤する際の退勤時間を変更

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -129,23 +129,22 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
-        .andThen((employeeId) => {
-          const clockOutParams = freee
+        .andThen((employeeId) =>
+          freee
             .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-            .andThen((workRecord) => {
-              if (workRecord.clock_in_at === null) return err("clock_in_at is null.");
-              const clockInAt = new Date(workRecord.clock_in_at);
-              const clockInPlusNineHours = addHours(clockInAt, 9);
-              const clockOutParams = {
-                company_id: FREEE_COMPANY_ID,
-                type: "clock_out" as const,
-                base_date: formatDate(yesterday, "date"),
-                datetime: formatDate(clockInPlusNineHours, "datetime"),
-              };
-              return ok(clockOutParams);
-            });
-          if (clockOutParams.isErr()) return err(clockOutParams.error);
-          return freee.setTimeClocks(employeeId, clockOutParams.value).andThen(() => ok(slackId));
+            .andThen((workRecord) => ok({ workRecord, employeeId }))
+        )
+        .andThen(({ workRecord, employeeId }) => {
+          if (workRecord.clock_in_at === null) return err("clock_in_at is null.");
+          const clockInAt = new Date(workRecord.clock_in_at);
+          const clockInPlusNineHours = addHours(clockInAt, 9);
+          const clockOutParams = {
+            company_id: FREEE_COMPANY_ID,
+            type: "clock_out" as const,
+            base_date: formatDate(yesterday, "date"),
+            datetime: formatDate(clockInPlusNineHours, "datetime"),
+          };
+          return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
         })
         .orElse((e) => err({ message: e, slackId }));
     })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -1,5 +1,5 @@
 import { GasWebClient as SlackClient } from "@hi-se/web-api";
-import { subDays, toDate, set, subHours, addHours } from "date-fns";
+import { subDays, toDate, set, addHours } from "date-fns";
 import { formatDate, Freee } from "./freee";
 import type { EmployeesWorkRecordsController_update_body } from "./freee.schema";
 import { getConfig } from "./config";

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -1,5 +1,5 @@
 import { GasWebClient as SlackClient } from "@hi-se/web-api";
-import { subDays, toDate, set } from "date-fns";
+import { subDays, toDate, set, subHours, addHours } from "date-fns";
 import { formatDate, Freee } from "./freee";
 import type { EmployeesWorkRecordsController_update_body } from "./freee.schema";
 import { getConfig } from "./config";
@@ -106,7 +106,6 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
 }
 
 function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId: string) {
-  const today = new Date();
   const yesterday = subDays(new Date(), 1);
 
   const { processedMessages, unprocessedMessages } = getCategorizedDailyMessages(
@@ -127,17 +126,22 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   });
   if (unClockedOutSlackIds.length === 0) return;
 
-  const clockOutParams = {
-    company_id: FREEE_COMPANY_ID,
-    type: "clock_out" as const,
-    //TODO: 指定する退勤時間を「出勤時間から9時間後」に変更する
-    base_date: formatDate(yesterday, "date"),
-    datetime: formatDate(today, "datetime"),
-  };
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
         .andThen((employeeId) => {
+          const workRecord = freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID);
+          if (workRecord.isErr() || workRecord.value.clock_in_at === null) {
+            return err({ message: workRecord, slackId });
+          }
+          const clockInAt = new Date(workRecord.value.clock_in_at);
+          const clockInPlusNineHours = addHours(clockInAt, 9);
+          const clockOutParams = {
+            company_id: FREEE_COMPANY_ID,
+            type: "clock_out" as const,
+            base_date: formatDate(yesterday, "date"),
+            datetime: formatDate(clockInPlusNineHours, "datetime"),
+          };
           return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
         })
         .orElse((e) => err({ message: e, slackId }));

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -133,9 +133,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
           const clockOutParams = freee
             .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
             .andThen((workRecord) => {
-              if (workRecord.clock_in_at === null) {
-                return err("clock_in_at is null.");
-              }
+              if (workRecord.clock_in_at === null) return err("clock_in_at is null.");
               const clockInAt = new Date(workRecord.clock_in_at);
               const clockInPlusNineHours = addHours(clockInAt, 9);
               const clockOutParams = {
@@ -146,7 +144,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
               };
               return ok(clockOutParams);
             });
-          if(clockOutParams.isErr()) return err(clockOutParams.error);
+          if (clockOutParams.isErr()) return err(clockOutParams.error);
           return freee.setTimeClocks(employeeId, clockOutParams.value).andThen(() => ok(slackId));
         })
         .orElse((e) => err({ message: e, slackId }));


### PR DESCRIPTION
このPRは、自動退勤システムの退勤時間の変更を行ったものである。
現状、実行した時間に退勤が押される仕組みになっている。
しかし、労働時間などの観点より出勤時間+9時間が適しているため変更を加えた。

変更内容
- 出勤時間に9時間を加えた時間を退勤時間にするように変更。
 FreeeAPIの勤怠取得を用いて出勤時間を取得:[APIリファレンス](https://developer.freee.co.jp/reference/hr/reference#operations-tag-勤怠)

[関連Notion](https://www.notion.so/siiibo/20f91f007d514e8db6187ae4d8287bf3?pvs=4)