### PR TITLE
feat: 自動退勤システムのリモートの際にメモを記入する機能を追加する (#CIT-597) 

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,7 +153,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 const newWorkRecord: EmployeesWorkRecordsController_update_body = {
                   company_id: FREEE_COMPANY_ID,
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
-                  clock_out_at: formatDate(yesterday, "datetime"),
+                  clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
                   break_records: workRecord.break_records.map((record) => {
                     return {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -136,7 +136,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(today, "datetime"),
           };
-          if (userStatus !== undefined && userStatus.workStatus === "勤務中（リモート）") {
+          if (userStatus?.workStatus === "勤務中（リモート）") {
             freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             freee
               .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -140,8 +140,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             freee
               .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-              .andThen((workRecord) => ok({ workRecord, employeeId }))
-              .andThen(({ workRecord }) => {
+              .andThen((workRecord) => {
                 if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
                   return err(`出勤時間が不正な値です.`);
                 }

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -13,13 +13,7 @@ import { match, P } from "ts-pattern";
 import { getUnixTimeStampString } from "./utilities";
 
 const DATE_START_HOUR = 4;
-type ClockOutParams = {
-  company_id: number;
-  type: "clock_out";
-  base_date: string;
-  datetime: string;
-  note?: string;
-};
+
 export function initAttendanceManager() {
   const targetFunction = periodicallyCheckForAttendanceManager;
 
@@ -130,7 +124,13 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     return userStatus !== undefined && userStatus.workStatus !== "退勤済み";
   });
   if (unClockedOutSlackIds.length === 0) return;
-
+  type ClockOutParams = {
+    company_id: number;
+    type: "clock_out";
+    base_date: string;
+    datetime: string;
+    note?: string;
+  };
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
@@ -265,7 +265,7 @@ function handleClockOut(
   const clockOutDate = message.date;
   const clockOutBaseDate = getBaseDate(message.date);
 
-  const clockOutParams:ClockOutParams = {
+  const clockOutParams = {
     company_id: FREEE_COMPANY_ID,
     type: "clock_out" as const,
     base_date: formatDate(clockOutBaseDate, "date"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -71,7 +71,7 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
     channelId,
     botUserId,
     DATE_START_HOUR,
-    today
+    today,
   );
   if (!unprocessedMessages.length && !processedMessages.length) return;
 
@@ -100,7 +100,7 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
           console.error(JSON.stringify({ userWorkStatus, ...error }, null, 2));
           client.chat.postMessage({ channel: channelId, text: error.message, thread_ts: message.ts });
           client.reactions.add({ channel: channelId, name: REACTION.ERROR, timestamp: message.ts });
-        }
+        },
       );
   });
 }
@@ -113,7 +113,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     channelId,
     botUserId,
     DATE_START_HOUR,
-    yesterday
+    yesterday,
   );
   if (!unprocessedMessages.length && !processedMessages.length) return;
 
@@ -132,7 +132,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
         .andThen((employeeId) =>
           freee
             .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-            .andThen((workRecord) => ok({ workRecord, employeeId }))
+            .andThen((workRecord) => ok({ workRecord, employeeId })),
         )
         .andThen(({ workRecord, employeeId }) => {
           if (workRecord.clock_in_at === null) return err("clock_in_at is null.");
@@ -143,11 +143,12 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             type: "clock_out" as const,
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(clockInPlusNineHours, "datetime"),
+            note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
           };
           return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
         })
         .orElse((e) => err({ message: e, slackId }));
-    })
+    }),
   ).match(
     (slackIds) => {
       const mentionIds = slackIds.map((slackId) => `<@${slackId}>`).join(", ");
@@ -164,7 +165,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     },
     (errors) => {
       console.error(JSON.stringify(errors, null, 2));
-    }
+    },
   );
 }
 
@@ -177,7 +178,7 @@ function execAction(
     message: Message;
     actionType: ActionType;
     userWorkStatus: UserWorkStatus | undefined;
-  }
+  },
 ) {
   const { message, actionType } = action;
   return getFreeeEmployeeIdFromSlackUserId(client, freee, message.user, freeCompanyId)
@@ -189,7 +190,7 @@ function execAction(
         .with("switch_work_status_to_remote", () => handleSwitchWorkStatusToRemote(client, channelId, message))
         .with("clock_out", () => handleClockOut(client, freee, channelId, freeCompanyId, employeeId, message))
         .with("clock_out_and_add_remote_memo", () =>
-          handleClockOutAndAddRemoteMemo(client, freee, channelId, freeCompanyId, employeeId, message)
+          handleClockOutAndAddRemoteMemo(client, freee, channelId, freeCompanyId, employeeId, message),
         )
         .exhaustive();
       return result
@@ -204,7 +205,7 @@ function handleClockIn(
   channelId: string,
   FREEE_COMPANY_ID: number,
   employeeId: number,
-  message: Message
+  message: Message,
 ) {
   const clockInDate = message.date;
 
@@ -225,11 +226,11 @@ function handleClockIn(
       return match(e)
         .with(
           P.when((e) => e.includes("打刻の種類が正しくありません。")),
-          () => err("既に打刻済みです")
+          () => err("既に打刻済みです"),
         )
         .with(
           P.when((e) => e.includes("打刻の日付が不正な値です。")),
-          () => err("前日の退勤を完了してから出勤打刻してください.")
+          () => err("前日の退勤を完了してから出勤打刻してください."),
         )
         .otherwise(() => err(e));
     });
@@ -251,7 +252,7 @@ function handleClockOut(
   channelId: string,
   FREEE_COMPANY_ID: number,
   employeeId: number,
-  message: Message
+  message: Message,
 ) {
   const clockOutDate = message.date;
   const clockOutBaseDate = getBaseDate(message.date);
@@ -273,7 +274,7 @@ function handleClockOut(
       return match(e)
         .with(
           P.when((e) => e.includes("打刻の種類が正しくありません。")),
-          () => err("出勤打刻が完了していないか、退勤の上書きができない値です.")
+          () => err("出勤打刻が完了していないか、退勤の上書きができない値です."),
         )
         .otherwise(() => err(e));
     });
@@ -285,7 +286,7 @@ function handleClockOutAndAddRemoteMemo(
   channelId: string,
   FREEE_COMPANY_ID: number,
   employeeId: number,
-  message: Message
+  message: Message,
 ) {
   const targetDate = formatDate(getBaseDate(message.date), "date");
 

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -142,13 +142,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
                 .andThen((workRecord) => {
                   if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                    return err(`出勤時間が不正な値です.`);
-                  }
-                  return ok(workRecord);
-                })
-                .andThen((workRecord) => {
-                  if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                    return err(`出勤時間または退勤時間がnullです.`);
+                    return err(`出勤時間が不正な値です`);
                   }
                   const newWorkRecord: EmployeesWorkRecordsController_update_body = {
                     company_id: FREEE_COMPANY_ID,

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -160,6 +160,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
                 .andThen(() => ok(slackId));
             });
+            return ok(slackId);
           }
           return ok(slackId);
         })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -137,7 +137,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
           {
             const userStatus = userWorkStatuses[slackId];
             if (userStatus !== undefined && userStatus.workStatus === "勤務中（リモート）") {
-              const clockOutParams = {
+              const newWorkRecord = {
                 company_id: FREEE_COMPANY_ID,
                 type: "clock_out" as const,
                 base_date: formatDate(yesterday, "date"),
@@ -145,16 +145,16 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
               };
               return freee
-                .updateWorkRecord(employeeId, formatDate(yesterday, "date"), clockOutParams)
+                .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
                 .andThen(() => ok(slackId));
             } else {
-              const newWorkRecord = {
+              const clockOutParams = {
                 company_id: FREEE_COMPANY_ID,
                 type: "clock_out" as const,
                 base_date: formatDate(yesterday, "date"),
                 datetime: formatDate(today, "datetime"),
               };
-              return freee.setTimeClocks(employeeId, newWorkRecord).andThen(() => ok(slackId));
+              return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             }
           }
         })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -128,26 +128,44 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
-        .andThen((employeeId) => {
-          {
-            const userStatus = userWorkStatuses[slackId];
-            const clockOutParams = {
+        .andThen((employeeId) => 
+          freee
+            .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
+            .andThen((workRecord) => ok({ workRecord, employeeId })
+        )
+        .andThen(({ workRecord, employeeId }) => {
+          if (workRecord.clock_in_at === null) {
+            return err(`出勤時間が不正な値です.`);
+          }
+          const userStatus = userWorkStatuses[slackId];
+          const clockOutParams = {
+            company_id: FREEE_COMPANY_ID,
+            type: "clock_out" as const,
+            base_date: formatDate(yesterday, "date"),
+            datetime: formatDate(today, "datetime"),
+          };
+          freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
+          if (userStatus !== undefined && userStatus.workStatus) {
+            const newWorkRecord: EmployeesWorkRecordsController_update_body = {
               company_id: FREEE_COMPANY_ID,
-              type: "clock_out" as const,
-              base_date: formatDate(yesterday, "date"),
-              datetime: formatDate(today, "datetime"),
-              ...(userStatus !== undefined && userStatus.workStatus === "勤務中（リモート）" && { note: "リモート" }),
+              clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
+              clock_out_at: formatDate(yesterday, "datetime"),
+              note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+              break_records: workRecord.break_records.map((record) => {
+                return {
+                  clock_in_at: formatDate(record.clock_in_at, "datetime"),
+                  clock_out_at: formatDate(record.clock_out_at, "datetime"),
+                };
+              }),
             };
-            if (`note` in clockOutParams) {
-              return freee
-                .updateWorkRecord(employeeId, formatDate(yesterday, "date"), clockOutParams)
-                .andThen(() => ok(slackId));
-            } else {
-              return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
-            }
+            return freee
+              .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
+              .andThen(() => ok(slackId));
+          }else{
+            return ok(slackId);
           }
         })
-        .orElse((e) => err({ message: e, slackId }));
+        .orElse((e) => err({ message: e, slackId })));
     }),
   ).match(
     (slackIds) => {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -142,8 +142,8 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
               base_date: formatDate(yesterday, "date"),
               datetime: formatDate(today, "datetime"),
             };
-            freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             if (userStatus !== undefined && userStatus.workStatus) {
+              freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
               const newWorkRecord: EmployeesWorkRecordsController_update_body = {
                 company_id: FREEE_COMPANY_ID,
                 clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
@@ -160,7 +160,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
                 .andThen(() => ok(slackId));
             } else {
-              return ok(slackId);
+              return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             }
           })
           .orElse((e) => err({ message: e, slackId })),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -139,11 +139,11 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
               ...(userStatus !== undefined && userStatus.workStatus === "勤務中（リモート）" && { note: "リモート" }),
             };
             if (`note` in clockOutParams) {
-              return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
-            } else {
               return freee
                 .updateWorkRecord(employeeId, formatDate(yesterday, "date"), clockOutParams)
                 .andThen(() => ok(slackId));
+            } else {
+              return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             }
           }
         })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -144,9 +144,9 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
                   return err(`出勤時間が不正な値です.`);
                 }
-                return ok({ workRecord });
+                return ok(workRecord);
               })
-              .andThen(({ workRecord }) => {
+              .andThen((workRecord) => {
                 if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
                   return err(`出勤時間または退勤時間がnullです.`);
                 }

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -140,7 +140,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
         .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];
           if (userStatus?.workStatus === "勤務中（リモート）") {
-            freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID).andThen((workRecord) => {
+            return freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID).andThen((workRecord) => {
               if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
                 return err(`出勤時間か退勤時間が不正な値です`);
               }
@@ -160,7 +160,6 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                 .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
                 .andThen(() => ok(slackId));
             });
-            return ok(slackId);
           }
           return ok(slackId);
         })

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -136,40 +136,40 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(today, "datetime"),
           };
-          if (userStatus?.workStatus === "勤務中（リモート）") {
-            freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
-            freee
-              .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-              .andThen((workRecord) => {
-                if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                  return err(`出勤時間が不正な値です.`);
-                }
-                return ok(workRecord);
-              })
-              .andThen((workRecord) => {
-                if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                  return err(`出勤時間または退勤時間がnullです.`);
-                }
-                const newWorkRecord: EmployeesWorkRecordsController_update_body = {
-                  company_id: FREEE_COMPANY_ID,
-                  clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
-                  clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
-                  note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                  break_records: workRecord.break_records.map((record) => {
-                    return {
-                      clock_in_at: formatDate(record.clock_in_at, "datetime"),
-                      clock_out_at: formatDate(record.clock_out_at, "datetime"),
-                    };
-                  }),
-                };
-                return freee
-                  .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
-                  .andThen(() => ok(slackId));
-              });
+          freee.setTimeClocks(employeeId, clockOutParams).andThen(() => {
+            if (userStatus?.workStatus === "勤務中（リモート）") {
+              freee
+                .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
+                .andThen((workRecord) => {
+                  if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
+                    return err(`出勤時間が不正な値です.`);
+                  }
+                  return ok(workRecord);
+                })
+                .andThen((workRecord) => {
+                  if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
+                    return err(`出勤時間または退勤時間がnullです.`);
+                  }
+                  const newWorkRecord: EmployeesWorkRecordsController_update_body = {
+                    company_id: FREEE_COMPANY_ID,
+                    clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
+                    clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
+                    note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+                    break_records: workRecord.break_records.map((record) => {
+                      return {
+                        clock_in_at: formatDate(record.clock_in_at, "datetime"),
+                        clock_out_at: formatDate(record.clock_out_at, "datetime"),
+                      };
+                    }),
+                  };
+                  return freee
+                    .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
+                    .andThen(() => ok(slackId));
+                });
+            }
             return ok(slackId);
-          } else {
-            return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
-          }
+          });
+          return ok(slackId);
         })
         .orElse((e) => err({ message: e, slackId }));
     }),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -135,8 +135,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(today, "datetime"),
           };
-          freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(employeeId));
-          return ok(employeeId);
+          return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(employeeId));
         })
         .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -135,7 +135,10 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(today, "datetime"),
           };
-          freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
+          freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(employeeId));
+          return ok(employeeId);
+        })
+        .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];
           if (userStatus?.workStatus === "勤務中（リモート）") {
             freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID).andThen((workRecord) => {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -146,7 +146,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
           const userStatus = userWorkStatuses[slackId];
           const clockOutParams: ClockOutParams = {
             company_id: FREEE_COMPANY_ID,
-            type: "clock_out",
+            type: "clock_out" as const,
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(clockInPlusNineHours, "datetime"),
           };

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -138,28 +138,26 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
           };
           freee.setTimeClocks(employeeId, clockOutParams).andThen(() => {
             if (userStatus?.workStatus === "勤務中（リモート）") {
-              freee
-                .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-                .andThen((workRecord) => {
-                  if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                    return err(`出勤時間が不正な値です`);
-                  }
-                  const newWorkRecord: EmployeesWorkRecordsController_update_body = {
-                    company_id: FREEE_COMPANY_ID,
-                    clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
-                    clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
-                    note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                    break_records: workRecord.break_records.map((record) => {
-                      return {
-                        clock_in_at: formatDate(record.clock_in_at, "datetime"),
-                        clock_out_at: formatDate(record.clock_out_at, "datetime"),
-                      };
-                    }),
-                  };
-                  return freee
-                    .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
-                    .andThen(() => ok(slackId));
-                });
+              freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID).andThen((workRecord) => {
+                if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
+                  return err(`出勤時間が不正な値です`);
+                }
+                const newWorkRecord: EmployeesWorkRecordsController_update_body = {
+                  company_id: FREEE_COMPANY_ID,
+                  clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
+                  clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
+                  note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+                  break_records: workRecord.break_records.map((record) => {
+                    return {
+                      clock_in_at: formatDate(record.clock_in_at, "datetime"),
+                      clock_out_at: formatDate(record.clock_out_at, "datetime"),
+                    };
+                  }),
+                };
+                return freee
+                  .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
+                  .andThen(() => ok(slackId));
+              });
             }
             return ok(slackId);
           });

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -128,7 +128,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
-        .andThen(( employeeId ) => {
+        .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];
           const clockOutParams = {
             company_id: FREEE_COMPANY_ID,
@@ -136,7 +136,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             base_date: formatDate(yesterday, "date"),
             datetime: formatDate(today, "datetime"),
           };
-          if (userStatus !== undefined && userStatus.workStatus) {
+          if (userStatus !== undefined && userStatus.workStatus === "勤務中（リモート）") {
             freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
             freee
               .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
@@ -167,6 +167,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   .updateWorkRecord(employeeId, formatDate(yesterday, "date"), newWorkRecord)
                   .andThen(() => ok(slackId));
               });
+            return ok(slackId);
           } else {
             return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
           }

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -140,7 +140,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             if (userStatus?.workStatus === "勤務中（リモート）") {
               freee.getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID).andThen((workRecord) => {
                 if (workRecord.clock_in_at === null || workRecord.clock_out_at === null) {
-                  return err(`出勤時間が不正な値です`);
+                  return err(`出勤時間か退勤時間が不正な値です`);
                 }
                 const newWorkRecord: EmployeesWorkRecordsController_update_body = {
                   company_id: FREEE_COMPANY_ID,


### PR DESCRIPTION
リモートの人が自動退勤システムで退勤が押された場合、freeeのメモに`リモート`と自動で記述されるような機能を追加した。

変更詳細(変更ありマージ前に変更する)
- ローカル型としてfreeeに渡すパラメータの型を作成した
- userStatusからリモート出勤なのかを判定しnoteに追加するように変更