### PR TITLE
fix: 廃止になったnormal_work_mins_by_paid_holidayプロパティの削除 (#CIT-599)

### DIFF
--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -50,7 +50,6 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   normal_work_clock_in_at: z.string().nullable(),
   normal_work_clock_out_at: z.string().nullable(),
   normal_work_mins: z.number().int(),
-  normal_work_mins_by_paid_holiday: z.number().int(),
   note: z.string().max(255),
   paid_holiday: z.number(),
   use_attendance_deduction: z.boolean(),
@@ -143,7 +142,6 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
     .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$/)
     .optional(),
   normal_work_mins: z.number().int().lte(1440).optional(),
-  normal_work_mins_by_paid_holiday: z.number().int().lte(1440).optional(),
   note: z.string().max(255).optional(),
   paid_holiday: z.number().lte(1).optional(),
   use_attendance_deduction: z.boolean().optional(),


### PR DESCRIPTION
[【freee人事労務】API仕様の変更について（勤怠API、勤怠情報サマリAPI）](https://developer.freee.co.jp/news/6774/)でアナウンスのあった変更に破壊的変更が含まれており、2024年2月上旬に`normal_work_mins_by_paid_holiday`プロパティが廃止される旨が記載されていた。

attendance-managerではこのプロパティを利用していないが、zodのSchema定義ではrequiredとしており、`handleClockOutAndAddRemoteMemo`関数内で`freee.getWorkRecord` を呼び出す際にparseエラー（requiredと定義されているプロパティにundefinedが渡ってきている）が発生していたため、`normal_work_mins_by_paid_holiday`プロパティを削除した。