### PR TITLE
feat: 自動退勤システムのslackコメントに修正後にスタンプを押すように指示を追加する (#CIT-604)

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -145,7 +145,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   ).match(
     (slackIds) => {
       const mentionIds = slackIds.map((slackId) => `<@${slackId}>`).join(", ");
-      const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください。`;
+      const message = `${mentionIds}\n前日に未退勤だったため自動退勤を行いました。freeeにログインして修正してください。\n修正したら :done: スタンプを押してください。`;
       const timeToPost = set(new Date(), { hours: 9, minutes: 0, seconds: 0 });
       const response = client.chat.scheduleMessage({
         channel: channelId,


### PR DESCRIPTION
自動退勤後に変更したのかがわかりやすいようにのslackのコメントを追加し、修正後に必ずスタンプを押してもらうようにする。

変更内容
- slackのコメントに「修正したら :done: スタンプを押してください。」を追加した