### PR TITLE
feat: 自動退勤に用いられる退勤時間をslackの出勤時間から計算するように変更する (#CIT-605)

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -1,5 +1,5 @@
 import { GasWebClient as SlackClient } from "@hi-se/web-api";
-import { subDays, toDate, set, addHours } from "date-fns";
+import { subDays, toDate, set } from "date-fns";
 import { formatDate, Freee } from "./freee";
 import type { EmployeesWorkRecordsController_update_body } from "./freee.schema";
 import { getConfig } from "./config";
@@ -106,6 +106,7 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
 }
 
 function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId: string) {
+  const today = new Date();
   const yesterday = subDays(new Date(), 1);
 
   const { processedMessages, unprocessedMessages } = getCategorizedDailyMessages(
@@ -126,24 +127,17 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
   });
   if (unClockedOutSlackIds.length === 0) return;
 
+  const clockOutParams = {
+    company_id: FREEE_COMPANY_ID,
+    type: "clock_out" as const,
+    //TODO: 指定する退勤時間を「出勤時間から9時間後」に変更する
+    base_date: formatDate(yesterday, "date"),
+    datetime: formatDate(today, "datetime"),
+  };
   Result.combineWithAllErrors(
     unClockedOutSlackIds.map((slackId) => {
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
-        .andThen((employeeId) =>
-          freee
-            .getWorkRecord(employeeId, formatDate(yesterday, "date"), FREEE_COMPANY_ID)
-            .andThen((workRecord) => ok({ workRecord, employeeId }))
-        )
-        .andThen(({ workRecord, employeeId }) => {
-          if (workRecord.clock_in_at === null) return err("clock_in_at is null.");
-          const clockInAt = new Date(workRecord.clock_in_at);
-          const clockInPlusNineHours = addHours(clockInAt, 9);
-          const clockOutParams = {
-            company_id: FREEE_COMPANY_ID,
-            type: "clock_out" as const,
-            base_date: formatDate(yesterday, "date"),
-            datetime: formatDate(clockInPlusNineHours, "datetime"),
-          };
+        .andThen((employeeId) => {
           return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(slackId));
         })
         .orElse((e) => err({ message: e, slackId }));

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -75,7 +75,7 @@ function checkAttendance(client: SlackClient, channelId: string, botUserId: stri
   );
   if (!unprocessedMessages.length && !processedMessages.length) return;
 
-  const userWorkStatuses = getUserWorkStatusesByMessages(unprocessedMessages, processedMessages);
+  const userWorkStatuses = getUserWorkStatusesByMessages(processedMessages);
 
   unprocessedMessages.forEach((message) => {
     const commandType = getCommandType(message);
@@ -116,7 +116,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
     yesterday,
   );
   if (!unprocessedMessages.length && !processedMessages.length) return;
-  const userWorkStatuses = getUserWorkStatusesByMessages(unprocessedMessages, processedMessages);
+  const userWorkStatuses = getUserWorkStatusesByMessages(processedMessages);
   const freee = new Freee();
   const { FREEE_COMPANY_ID } = getConfig();
   const unClockedOutSlackIds = Object.keys(userWorkStatuses).filter((slackId) => {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -130,7 +130,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
         .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];
           if (!userStatus?.clockInTime) return err(`userStatus or userStatus.clockInTime is undefined`);
-          const clockInPlusNineHours = addHours(userStatus.clockInTime, 9);
+          const clockInTimePlusNineHours = addHours(userStatus.clockInTime, 9);
           const clockOutParams = {
             company_id: FREEE_COMPANY_ID,
             type: "clock_out" as const,

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -129,7 +129,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
       return getFreeeEmployeeIdFromSlackUserId(client, freee, slackId, FREEE_COMPANY_ID)
         .andThen((employeeId) => {
           const userStatus = userWorkStatuses[slackId];
-          if (!userStatus) return err(`userStatus is undefined`);
+          if (!userStatus || !userStatus.clockInTime) return err(`userStatus is undefined`);
           const clockInPlusNineHours = addHours(userStatus.clockInTime, 9);
           const clockOutParams = {
             company_id: FREEE_COMPANY_ID,

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -135,7 +135,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
             company_id: FREEE_COMPANY_ID,
             type: "clock_out" as const,
             base_date: formatDate(yesterday, "date"),
-            datetime: formatDate(clockInPlusNineHours, "datetime"),
+            datetime: formatDate(clockInTimePlusNineHours, "datetime"),
           };
           return freee.setTimeClocks(employeeId, clockOutParams).andThen(() => ok(employeeId));
         })

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -35,7 +35,7 @@ export function getUpdatedUserWorkStatus(
     processedCommands: userCommands,
   };
 }
-function getClockInTimeByUser(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
+function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
@@ -58,7 +58,7 @@ export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessag
       .filter((command): command is CommandType => command !== undefined);
     const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
-    const clockInTime = getClockInTimeByUser(processedMessages, userSlackId);
+    const clockInTime = getClockInTimeByUserSlackId(processedMessages, userSlackId);
     const userWorkStatus: UserWorkStatus = {
       clockInTime,
       workStatus,

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -36,6 +36,16 @@ export function getUpdatedUserWorkStatus(
     processedCommands: userCommands,
   };
 }
+function getClockInDateForUser(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
+  const slackClockInResult = processedMessages.filter((message) => {
+    const commandType = getCommandType(message);
+    if (!commandType) return false;
+    if (userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {
+      return true;
+    }
+  });
+  return slackClockInResult.length ? slackClockInResult[0].date : undefined;
+}
 
 export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessage[]): {
   [userSlackId: string]: UserWorkStatus | undefined;
@@ -49,14 +59,10 @@ export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessag
       .filter((command): command is CommandType => command !== undefined);
     const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
-    const slackClockInResult = processedMessages.filter((message) => {
-      const commandType = getCommandType(message);
-      if (!commandType) return false;
-      if (userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {
-        return true;
-      }
-    });
-    const clockInTime = slackClockInResult[0].date;
+    const clockInTime = getClockInDateForUser(processedMessages, userSlackId);
+    if (clockInTime === undefined) {
+      return [userSlackId, undefined];
+    }
     const userWorkStatus: UserWorkStatus = {
       clockInTime,
       workStatus,

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -39,9 +39,8 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
-    if (userSlackId === message.user && commandType === "CLOCK_IN") {
-      return true;
-    }
+    if (userSlackId === message.user && commandType === "CLOCK_IN") return true;
+    return false;
   });
   return slackClockInResult.length ? slackClockInResult[0].date : undefined;
 }

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -12,6 +12,7 @@ export const WORK_STATUS = {
 } as const;
 
 export type UserWorkStatus = {
+  clockInTime: Date;
   workStatus: valueOf<typeof WORK_STATUS>;
   needTrafficExpense: boolean;
   processedCommands: CommandType[];

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -20,15 +20,17 @@ export type UserWorkStatus = {
 
 export function getUpdatedUserWorkStatus(
   userWorkStatus: UserWorkStatus | undefined,
-  newCommand: CommandType
+  newCommand: CommandType,
 ): UserWorkStatus {
   const userCommands = userWorkStatus ? [...userWorkStatus.processedCommands, newCommand] : [newCommand];
   const workStatus = getUserWorkStatusByCommands(userCommands);
   const needTrafficExpense = userWorkStatus?.needTrafficExpense
     ? userWorkStatus.needTrafficExpense
     : checkTrafficExpense(userCommands);
-
+  const clockInTime = userWorkStatus?.clockInTime;
+  if (clockInTime === undefined) throw new Error("clockInTime is undefined");
   return {
+    clockInTime: clockInTime,
     needTrafficExpense,
     workStatus,
     processedCommands: userCommands,

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -39,7 +39,7 @@ function getClockInTimeByUser(processedMessages: ProcessedMessage[], userSlackId
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
-    if (userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {
+    if (userSlackId === message.user && commandType === "CLOCK_IN") {
       return true;
     }
   });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -35,7 +35,7 @@ export function getUpdatedUserWorkStatus(
     processedCommands: userCommands,
   };
 }
-function getClockInDateForUser(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
+function getClockInTimeByUser(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
@@ -58,7 +58,7 @@ export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessag
       .filter((command): command is CommandType => command !== undefined);
     const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
-    const clockInTime = getClockInDateForUser(processedMessages, userSlackId);
+    const clockInTime = getClockInTimeByUser(processedMessages, userSlackId);
     const userWorkStatus: UserWorkStatus = {
       clockInTime,
       workStatus,

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -12,7 +12,7 @@ export const WORK_STATUS = {
 } as const;
 
 export type UserWorkStatus = {
-  clockInTime: Date;
+  clockInTime?: Date;
   workStatus: valueOf<typeof WORK_STATUS>;
   needTrafficExpense: boolean;
   processedCommands: CommandType[];
@@ -28,7 +28,6 @@ export function getUpdatedUserWorkStatus(
     ? userWorkStatus.needTrafficExpense
     : checkTrafficExpense(userCommands);
   const clockInTime = userWorkStatus?.clockInTime;
-  if (clockInTime === undefined) throw new Error("clockInTime is undefined");
   return {
     clockInTime,
     needTrafficExpense,
@@ -60,9 +59,6 @@ export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessag
     const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
     const clockInTime = getClockInDateForUser(processedMessages, userSlackId);
-    if (clockInTime === undefined) {
-      return [userSlackId, undefined];
-    }
     const userWorkStatus: UserWorkStatus = {
       clockInTime,
       workStatus,

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -1,7 +1,7 @@
 import { match } from "ts-pattern";
 import * as R from "remeda";
 import { CommandType, getCommandType } from "./command";
-import { UnprocessedMessage, ProcessedMessage } from "./message";
+import { ProcessedMessage } from "./message";
 import { valueOf } from "./utilities";
 
 // 未出勤は現状利用していない
@@ -37,10 +37,7 @@ export function getUpdatedUserWorkStatus(
   };
 }
 
-export function getUserWorkStatusesByMessages(
-  unprocessedMessages: UnprocessedMessage[],
-  processedMessages: ProcessedMessage[],
-): {
+export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessage[]): {
   [userSlackId: string]: UserWorkStatus | undefined;
 } {
   // TODO: ↓ 「今誰いる？」の機能に流用する
@@ -52,7 +49,7 @@ export function getUserWorkStatusesByMessages(
       .filter((command): command is CommandType => command !== undefined);
     const workStatus = getUserWorkStatusByCommands(userCommands);
     const needTrafficExpense = checkTrafficExpense(userCommands);
-    const slackClockInResult = unprocessedMessages.filter((message) => {
+    const slackClockInResult = processedMessages.filter((message) => {
       const commandType = getCommandType(message);
       if (!commandType) return false;
       if (userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -39,7 +39,9 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
-    if (userSlackId === message.user && commandType === "CLOCK_IN") return true;
+    if (userSlackId === message.user && commandType === "CLOCK_IN") {
+      return true;
+    }
     return false;
   });
   return slackClockInResult.length ? slackClockInResult[0].date : undefined;

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -54,7 +54,8 @@ export function getUserWorkStatusesByMessages(
     const needTrafficExpense = checkTrafficExpense(userCommands);
     const slackClockInResult = unprocessedMessages.filter((message) => {
       const commandType = getCommandType(message);
-      if (commandType && userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {
+      if (!commandType) return false;
+      if (userSlackId === message.user && commandType === "CLOCK_IN" && commandType) {
         return true;
       }
     });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -30,7 +30,7 @@ export function getUpdatedUserWorkStatus(
   const clockInTime = userWorkStatus?.clockInTime;
   if (clockInTime === undefined) throw new Error("clockInTime is undefined");
   return {
-    clockInTime: clockInTime,
+    clockInTime,
     needTrafficExpense,
     workStatus,
     processedCommands: userCommands,
@@ -61,7 +61,7 @@ export function getUserWorkStatusesByMessages(
     });
     const clockInTime = slackClockInResult[0].date;
     const userWorkStatus: UserWorkStatus = {
-      clockInTime: clockInTime,
+      clockInTime,
       workStatus,
       needTrafficExpense,
       processedCommands: userCommands,


### PR DESCRIPTION
自動退勤システムの退勤時間を**slackのメッセージの出勤時間**+9時間にするように変更する。
#70 で実装していたが、FreeeのAPIで取得できる`clock_in_at`が退勤が押された場合に確定されるため、`clock_in_at`が見つからないとエラーが発生してしまっていた。

変更詳細
- UserWorkStatus型にclockInTimeを追加し出勤時間を取得できるようにした
- userWorkStatusesから出勤時間を取得し+9時間の時間で退勤を押すようにした