### PR TITLE
fix: 自動退勤の出勤時間の取得の際のスタンプ条件を修正 (#CIT-616)

### DIFF
--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -36,26 +36,16 @@ export function getUpdatedUserWorkStatus(
   };
 }
 function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
-  const filteredUserMessages = processedMessages.filter((message) => {
-    const commandType = getCommandType(message);
-    if (!commandType) return false;
-    if (userSlackId === message.user) {
-      return true;
-    }
-    return false;
-  });
-  const slackClockInResult = filteredUserMessages.filter((message) => {
-    const commandType = getCommandType(message);
-    if (!commandType) return false;
-    if (
-      commandType === "CLOCK_IN" ||
-      commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE" ||
-      commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE"
-    ) {
-      return true;
-    }
-    return false;
-  });
+  const slackClockInResult = processedMessages
+    .filter((message) => message.user === userSlackId)
+    .filter((message) => {
+      const commandType = getCommandType(message);
+      return (
+        commandType === "CLOCK_IN" ||
+        commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE" ||
+        commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE"
+      );
+    });
   return slackClockInResult.length ? slackClockInResult[0].date : undefined;
 }
 

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -41,7 +41,9 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
     if (!commandType) return false;
     if (
       userSlackId === message.user &&
-      (commandType === "CLOCK_IN" || commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE")
+      (commandType === "CLOCK_IN" ||
+        commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE" ||
+        commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE")
     ) {
       return true;
     }

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -36,13 +36,23 @@ export function getUpdatedUserWorkStatus(
   };
 }
 function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
-  const slackClockInResult = processedMessages.filter((message) => {
+  const filteredUserMessages = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
     if (userSlackId === message.user) {
-      if (commandType === "CLOCK_IN" || commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE"){
-        return true;
-      }
+      return true;
+    }
+    return false;
+  });
+  const slackClockInResult = filteredUserMessages.filter((message) => {
+    const commandType = getCommandType(message);
+    if (!commandType) return false;
+    if (
+      commandType === "CLOCK_IN" ||
+      commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE" ||
+      commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE"
+    ) {
+      return true;
     }
     return false;
   });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -39,13 +39,10 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
-    if (
-      userSlackId === message.user &&
-      (commandType === "CLOCK_IN" ||
-        commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE" ||
-        commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE")
-    ) {
-      return true;
+    if (userSlackId === message.user) {
+      if (commandType === "CLOCK_IN" || commandType === "CLOCK_IN_OR_SWITCH_TO_OFFICE"){
+        return true;
+      }
     }
     return false;
   });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -44,7 +44,6 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
       (commandType === "CLOCK_IN" || commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE")
     ) {
       return true;
-      
     }
     return false;
   });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -39,8 +39,12 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
   const slackClockInResult = processedMessages.filter((message) => {
     const commandType = getCommandType(message);
     if (!commandType) return false;
-    if (userSlackId === message.user && commandType === "CLOCK_IN") {
+    if (
+      userSlackId === message.user &&
+      (commandType === "CLOCK_IN" || commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE")
+    ) {
       return true;
+      
     }
     return false;
   });

--- a/attendance-manager/src/userWorkStatus.ts
+++ b/attendance-manager/src/userWorkStatus.ts
@@ -36,7 +36,7 @@ export function getUpdatedUserWorkStatus(
   };
 }
 function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], userSlackId: string): Date | undefined {
-  const slackClockInResult = processedMessages
+  const userClockInMessages = processedMessages
     .filter((message) => message.user === userSlackId)
     .filter((message) => {
       const commandType = getCommandType(message);
@@ -46,7 +46,7 @@ function getClockInTimeByUserSlackId(processedMessages: ProcessedMessage[], user
         commandType === "CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE"
       );
     });
-  return slackClockInResult.length ? slackClockInResult[0].date : undefined;
+  return userClockInMessages.length ? userClockInMessages[0].date : undefined;
 }
 
 export function getUserWorkStatusesByMessages(processedMessages: ProcessedMessage[]): {


### PR DESCRIPTION
自動退勤システムの出勤時間を取得する際のスタンプの条件を修正した。
修正前は、`出勤`スタンプのみの時間を取得し出勤時間を取得していた。しかし、勤務開始のスタンプは3種類あったので条件を変更し対応できるようにした。

変更詳細
- commandTypeの条件に`CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE`:リモートスタンプを追加
- commandTypeの条件に`CLOCK_IN_OR_SWITCH_TO_OFFICE`:出社スタンプを追加

___
勤務開始のスタンプの種類は3つある。
1. 出勤 → ただの出勤 : `CLOCK_IN`
2. 出社 → `リモート→出社`の勤務場所切り替えや`出勤`のどちらも使える: `CLOCK_IN_OR_SWITCH_TO_OFFICE`
3. リモート出勤 → リモート出勤 : `CLOCK_IN_AND_ALL_DAY_REMOTE_OR_SWITCH_TO_ALL_DAY_REMOTE`