### PR TITLE
fix: updateWorkRecordを行う際に半休情報を含めて更新を行うようにする (#CIT-624)

### DIFF
--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -325,6 +325,8 @@ function handleClockOutAndAddRemoteMemo(
         clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+        half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+        half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,6 +153,8 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+                  half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,9 +153,9 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                  special_holiday_setting_id: workRecord.special_holiday_setting_id,
-                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-                  half_special_holiday_mins: workRecord.half_special_holiday_mins,
+                  special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id:undefined,
+                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins:undefined,
+                  half_special_holiday_mins: workRecord.half_special_holiday_mins ? workRecord.half_special_holiday_mins:undefined,
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),
@@ -326,9 +326,9 @@ function handleClockOutAndAddRemoteMemo(
         clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-        half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-        special_holiday_setting_id: workRecord.special_holiday_setting_id,
-        half_special_holiday_mins: workRecord.half_special_holiday_mins,
+        half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins:undefined,
+        special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id:undefined,
+        half_special_holiday_mins: workRecord.half_special_holiday_mins ? workRecord.half_special_holiday_mins:undefined,
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,15 +153,9 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                  special_holiday_setting_id: workRecord.special_holiday_setting_id
-                    ? workRecord.special_holiday_setting_id
-                    : undefined,
-                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins
-                    ? workRecord.half_paid_holiday_mins
-                    : undefined,
-                  half_special_holiday_mins: workRecord.half_special_holiday_mins
-                    ? workRecord.half_special_holiday_mins
-                    : undefined,
+                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+                  special_holiday_setting_id: workRecord.special_holiday_setting_id,
+                  half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),
@@ -332,13 +326,9 @@ function handleClockOutAndAddRemoteMemo(
         clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-        half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins : undefined,
-        special_holiday_setting_id: workRecord.special_holiday_setting_id
-          ? workRecord.special_holiday_setting_id
-          : undefined,
-        half_special_holiday_mins: workRecord.half_special_holiday_mins
-          ? workRecord.half_special_holiday_mins
-          : undefined,
+        half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+        special_holiday_setting_id: workRecord.special_holiday_setting_id,
+        half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,6 +153,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
+                  special_holiday_setting_id: workRecord.special_holiday_setting_id,
                   half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
                   half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
@@ -326,6 +327,7 @@ function handleClockOutAndAddRemoteMemo(
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
         half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+        special_holiday_setting_id: workRecord.special_holiday_setting_id,
         half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {
           return {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -154,7 +154,9 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
                   half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-                  special_holiday_setting_id: workRecord.special_holiday_setting_id,
+                  special_holiday_setting_id: workRecord.special_holiday_setting_id
+                    ? workRecord.special_holiday_setting_id
+                    : 0,
                   hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
                   half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
@@ -328,7 +330,7 @@ function handleClockOutAndAddRemoteMemo(
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
         half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-        special_holiday_setting_id: workRecord.special_holiday_setting_id,
+        special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id : 0,
         hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
         half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,7 +153,9 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+                  ...(workRecord.half_paid_holiday_mins && {
+                    half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
+                  }),
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -154,16 +154,16 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
                   half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-                  special_holiday_setting_id: workRecord.special_holiday_setting_id
-                    ? workRecord.special_holiday_setting_id
-                    : 0,
-                  hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
-                  half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),
                       clock_out_at: formatDate(record.clock_out_at, "datetime"),
                     };
+                  }),
+                  ...(workRecord.special_holiday_setting_id && {
+                    special_holiday_setting_id: workRecord.special_holiday_setting_id,
+                    hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
+                    half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   }),
                 };
                 return freee
@@ -330,14 +330,16 @@ function handleClockOutAndAddRemoteMemo(
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
         half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
-        special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id : 0,
-        hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
-        half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),
             clock_out_at: formatDate(record.clock_out_at, "datetime"),
           };
+        }),
+        ...(workRecord.special_holiday_setting_id && {
+          special_holiday_setting_id: workRecord.special_holiday_setting_id,
+          hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
+          half_special_holiday_mins: workRecord.half_special_holiday_mins,
         }),
       };
       return freee.updateWorkRecord(employeeId, targetDate, newWorkRecord);

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -162,7 +162,6 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   }),
                   ...(workRecord.special_holiday_setting_id && {
                     special_holiday_setting_id: workRecord.special_holiday_setting_id,
-                    hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
                     half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   }),
                 };
@@ -338,7 +337,6 @@ function handleClockOutAndAddRemoteMemo(
         }),
         ...(workRecord.special_holiday_setting_id && {
           special_holiday_setting_id: workRecord.special_holiday_setting_id,
-          hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
           half_special_holiday_mins: workRecord.half_special_holiday_mins,
         }),
       };

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -153,9 +153,15 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
                   clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-                  special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id:undefined,
-                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins:undefined,
-                  half_special_holiday_mins: workRecord.half_special_holiday_mins ? workRecord.half_special_holiday_mins:undefined,
+                  special_holiday_setting_id: workRecord.special_holiday_setting_id
+                    ? workRecord.special_holiday_setting_id
+                    : undefined,
+                  half_paid_holiday_mins: workRecord.half_paid_holiday_mins
+                    ? workRecord.half_paid_holiday_mins
+                    : undefined,
+                  half_special_holiday_mins: workRecord.half_special_holiday_mins
+                    ? workRecord.half_special_holiday_mins
+                    : undefined,
                   break_records: workRecord.break_records.map((record) => {
                     return {
                       clock_in_at: formatDate(record.clock_in_at, "datetime"),
@@ -326,9 +332,13 @@ function handleClockOutAndAddRemoteMemo(
         clock_in_at: formatDate(workRecord.clock_in_at, "datetime"),
         clock_out_at: formatDate(workRecord.clock_out_at, "datetime"),
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
-        half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins:undefined,
-        special_holiday_setting_id: workRecord.special_holiday_setting_id ? workRecord.special_holiday_setting_id:undefined,
-        half_special_holiday_mins: workRecord.half_special_holiday_mins ? workRecord.half_special_holiday_mins:undefined,
+        half_paid_holiday_mins: workRecord.half_paid_holiday_mins ? workRecord.half_paid_holiday_mins : undefined,
+        special_holiday_setting_id: workRecord.special_holiday_setting_id
+          ? workRecord.special_holiday_setting_id
+          : undefined,
+        half_special_holiday_mins: workRecord.half_special_holiday_mins
+          ? workRecord.half_special_holiday_mins
+          : undefined,
         break_records: workRecord.break_records.map((record) => {
           return {
             clock_in_at: formatDate(record.clock_in_at, "datetime"),

--- a/attendance-manager/src/attendanceManager.ts
+++ b/attendance-manager/src/attendanceManager.ts
@@ -155,6 +155,7 @@ function autoCheckAndClockOut(client: SlackClient, channelId: string, botUserId:
                   note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
                   half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
                   special_holiday_setting_id: workRecord.special_holiday_setting_id,
+                  hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
                   half_special_holiday_mins: workRecord.half_special_holiday_mins,
                   break_records: workRecord.break_records.map((record) => {
                     return {
@@ -328,6 +329,7 @@ function handleClockOutAndAddRemoteMemo(
         note: workRecord.note ? `${workRecord.note} リモート` : "リモート",
         half_paid_holiday_mins: workRecord.half_paid_holiday_mins,
         special_holiday_setting_id: workRecord.special_holiday_setting_id,
+        hourly_special_holiday_mins: workRecord.hourly_special_holiday_mins,
         half_special_holiday_mins: workRecord.half_special_holiday_mins,
         break_records: workRecord.break_records.map((record) => {
           return {

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -64,7 +64,7 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
   half_paid_holiday_mins: z.number().int(),
   half_special_holiday_mins: z.number().int(),
-  special_holiday_setting_id: z.number().int(),
+  special_holiday_setting_id: z.number().int().nullable(),
 });
 
 const EmployeesWorkRecordSummarySerializerSchema = z.object({
@@ -151,7 +151,7 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   use_default_work_pattern: z.boolean().optional(),
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
-  special_holiday_setting_id: z.number().int().optional(),
+  special_holiday_setting_id: z.number().int().optional().nullable(),
 });
 
 export const schemas = {

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -64,7 +64,6 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
   half_paid_holiday_mins: z.number().int(),
   half_special_holiday_mins: z.number().int(),
-  hourly_special_holiday_mins: z.number().int(),
   special_holiday_setting_id: z.number().int().nullable(),
 });
 
@@ -152,7 +151,6 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   use_default_work_pattern: z.boolean().optional(),
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
-  hourly_special_holiday_mins: z.number().int().optional(),
   special_holiday_setting_id: z.number().int().optional(),
 });
 

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -64,6 +64,7 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
   half_paid_holiday_mins: z.number().int(),
   half_special_holiday_mins: z.number().int(),
+  hourly_special_holiday_mins: z.number().int(),
   special_holiday_setting_id: z.number().int().nullable(),
 });
 
@@ -151,6 +152,7 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   use_default_work_pattern: z.boolean().optional(),
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
+  hourly_special_holiday_mins: z.number().int().optional(),
   special_holiday_setting_id: z.number().int().optional(),
 });
 

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -153,7 +153,7 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
   hourly_special_holiday_mins: z.number().int().optional(),
-  special_holiday_setting_id: z.number().int().optional().nullable(),
+  special_holiday_setting_id: z.number().int().optional(),
 });
 
 export const schemas = {

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -62,6 +62,8 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_excess_statutory_work_mins: z.number().int(),
   total_overtime_except_normal_work_mins: z.number().int(),
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
+  half_paid_holiday_mins: z.number().int(),
+  half_special_holiday_mins: z.number().int(),
 });
 
 const EmployeesWorkRecordSummarySerializerSchema = z.object({
@@ -146,6 +148,8 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   paid_holiday: z.number().lte(1).optional(),
   use_attendance_deduction: z.boolean().optional(),
   use_default_work_pattern: z.boolean().optional(),
+  half_paid_holiday_mins: z.number().int().optional(),
+  half_special_holiday_mins: z.number().int().optional(),
 });
 
 export const schemas = {

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -64,6 +64,7 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
   half_paid_holiday_mins: z.number().int(),
   half_special_holiday_mins: z.number().int(),
+  special_holiday_setting_id: z.number().int(),
 });
 
 const EmployeesWorkRecordSummarySerializerSchema = z.object({
@@ -150,6 +151,7 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   use_default_work_pattern: z.boolean().optional(),
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
+  special_holiday_setting_id: z.number().int().optional(),
 });
 
 export const schemas = {

--- a/attendance-manager/src/freee.schema.ts
+++ b/attendance-manager/src/freee.schema.ts
@@ -64,6 +64,7 @@ const EmployeesWorkRecordSerializerSchema = z.object({
   total_latenight_overtime_except_normal_work_mins: z.number().int(),
   half_paid_holiday_mins: z.number().int(),
   half_special_holiday_mins: z.number().int(),
+  hourly_special_holiday_mins: z.number().int(),
   special_holiday_setting_id: z.number().int().nullable(),
 });
 
@@ -151,6 +152,7 @@ const EmployeesWorkRecordsControllerSchema_update_body = z.object({
   use_default_work_pattern: z.boolean().optional(),
   half_paid_holiday_mins: z.number().int().optional(),
   half_special_holiday_mins: z.number().int().optional(),
+  hourly_special_holiday_mins: z.number().int().optional(),
   special_holiday_setting_id: z.number().int().optional().nullable(),
 });
 


### PR DESCRIPTION
Freee上で半休登録を行い、その後リモートで仕事を行い退勤を行った際に半休情報が消えてしまっていた。

リモート出勤で退勤を押すと、Freee上のメモを記述するために打刻を更新し登録を行っている。しかし、登録を更新する際に半休情報を切り捨てて更新を行ってしまっていた。

変更内容
- メモを登録するために用いていた`updateWorkRecord`に半休の時間を与えるように変更
- 半休の時間を取得するために`getWorkRecord`の型を変更