### PR TITLE
fix: 月末の深夜に退勤した場合に打刻が正常に完了しないバグの修正 (#CIT-964)

### DIFF
--- a/attendance-manager/src/message.test.ts
+++ b/attendance-manager/src/message.test.ts
@@ -8,6 +8,7 @@ describe("getDayStartAsDate", () => {
       { date: "2023-03-05T00:00:00+09:00", expected: "2023-03-04T04:00:00+09:00" },
       { date: "2023-03-04T00:05:00+09:00", expected: "2023-03-03T04:00:00+09:00" },
       { date: "2023-03-03T03:59:00+09:00", expected: "2023-03-02T04:00:00+09:00" },
+      { date: "2024-10-01T00:20:00+09:00", expected: "2024-09-30T04:00:00+09:00" },
     ];
     testCases.forEach((testCase) => {
       const date = new Date(testCase.date);

--- a/attendance-manager/src/message.ts
+++ b/attendance-manager/src/message.ts
@@ -75,12 +75,12 @@ function getDailyMessages(client: SlackClient, channelId: string, dateStartHour:
 }
 
 export function getDayStartAsDate(date: Date, dateStartHour: number): Date {
-  return set(date, {
+  const baseDate = date.getHours() < dateStartHour ? subDays(date, 1) : date;
+  return set(baseDate, {
     hours: dateStartHour,
     minutes: 0,
     seconds: 0,
     milliseconds: 0,
-    ...(date.getHours() < dateStartHour && { date: getDate(subDays(date, 1)) }),
   });
 }
 


### PR DESCRIPTION
https://siiibo.slack.com/archives/CL0V50APP/p1727740892476559?thread_ts=1727740806.556919&cid=CL0V50APP で発覚。

月跨ぎ & 深夜0:00を過ぎたタイミング（翌月初になったタイミング）で打刻すると打刻が機能しないバグを修正。
