### PR TITLE
chore: chore: type-checkとlint用のnpm scriptsを追加 (#CIT-981)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.formatOnPaste": false,
   "editor.formatOnType": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "terminal.integrated.defaultProfile.linux": "fish",

--- a/attendance-aggregation/package.json
+++ b/attendance-aggregation/package.json
@@ -9,8 +9,9 @@
     "build": "webpack",
     "prepush": "mkdir -p build && cp appsscript.json build/appsscript.json",
     "buildpush": "pnpm build && pnpm prepush && clasp push --force",
-    "postinstall": "mkdir -p build && cp appsscript.json build/appsscript.json",
-    "create": "pwd | awk -F'/' '{print $NF}' | xargs -I {} clasp create --rootDir build --title {} --type standalone && mv build/.clasp.json ./"
+    "lint": "eslint src/**/*",
+    "lint-fix": "pnpm lint --fix",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hi-se/web-api": "https://gitpkg.now.sh/hi-se/node-slack-sdk/packages/web-api?ab078b145617d511327a8f74fe34f1d4695ff893",

--- a/attendance-manager/package.json
+++ b/attendance-manager/package.json
@@ -11,7 +11,10 @@
     "build": "webpack",
     "prepush": "mkdir -p build && cp appsscript.json build/appsscript.json",
     "buildpush:prod": "pnpm build && pnpm prepush && cross-env clasp_config_project=.clasp.prod.json clasp push --force",
-    "buildpush:dev": "pnpm build && pnpm prepush && cross-env clasp_config_project=.clasp.dev.json clasp push --force"
+    "buildpush:dev": "pnpm build && pnpm prepush && cross-env clasp_config_project=.clasp.dev.json clasp push --force",
+    "lint": "eslint src/**/*",
+    "lint-fix": "pnpm lint --fix",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hi-se/web-api": "https://gitpkg.now.sh/hi-se/node-slack-sdk/packages/web-api?ab078b145617d511327a8f74fe34f1d4695ff893",


### PR DESCRIPTION
GitHub Actionsとdependabot導入に向けた前準備として、type-checkとlint用のnpm scriptsを追加した。

